### PR TITLE
Fixes for Windows support

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -208,7 +208,7 @@ def generate_testfile(sourcefile,destfile,minsize):
             dst.write(data)
     dst.close()
 
-def runcommand(command, env=None, stoponfail=1, silent=1, output='/dev/null'):
+def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
     ''' Run command, and handle special cases '''
     args = shlex.split(command)
     if (silent == 1):

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -322,7 +322,7 @@ def runtest(tempfiles,level):
         os.unlink(timefile)
     os.unlink(compfile)
 
-    printnn(f" {comptime:.3f} {decomptime:.3f}")
+    printnn(f" {comptime:7.3f} {decomptime:7.3f} {compsize}")
     printnn('\n')
 
     return compsize,comptime,decomptime,hashfail

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -213,12 +213,15 @@ def generate_testfile(sourcefile,destfile,minsize):
 def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
     ''' Run command, and handle special cases '''
     args = shlex.split(command, posix=sys.platform != 'win32')
+    sp_args = {}
+    if (sys.platform == 'win32'):
+        sp_args['creationflags'] = subprocess.HIGH_PRIORITY_CLASS
     if (silent == 1):
         devnull = open(output, 'w')
-        retval = subprocess.call(args,env=env,stdout=devnull)
+        retval = subprocess.call(args,env=env,stdout=devnull,**sp_args)
         devnull.close()
     else:
-        retval = subprocess.call(args,env=env)
+        retval = subprocess.call(args,env=env,**sp_args)
     if ((retval != 0) and (stoponfail != 0)):
         sys.exit(f"Failed, retval({retval}): {command}")
     return retval

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -266,7 +266,8 @@ def runtest(tempfiles,level):
     cmdprefix = command_prefix(timefile)
 
     sys.stdout.write(f"Testing level {level}: ")
-    runcommand('sync')
+     if sys.platform != 'win32':
+        runcommand('sync')
 
     # Compress
     printnn('c')

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -604,7 +604,7 @@ def main():
             sys.exit(1)
         cfgRuns['testtool'] = 'minideflate'
 
-    if cfgRuns['testtool'] != 'minigzip' and cfgRuns['testtool'] != 'minideflate':
+    if 'minigzip' not in cfgRuns['testtool'] and 'minideflate' not in cfgRuns['testtool']:
         print("Error, config file spesifies invalid testtool. Valid choices are 'minigzip' and 'minideflate'.")
         sys.exit(1)
 

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -24,6 +24,7 @@ import os, os.path
 import sys
 import re
 import math
+import tempfile
 import time
 import toml
 import shlex
@@ -74,7 +75,7 @@ def defconfig():
                             'testmode': 'single',  # generate / multi / single
                             'testtool': 'minigzip' } # minigzip / minideflate
 
-    config['Config'] = {'temp_path': "/tmp/",
+    config['Config'] = {'temp_path': tempfile.gettempdir(),
                         'use_perf': True,
                         'start_delay': 0,   # Milliseconds of startup to skip measuring, requires usleep(X*1000) in minigzip/minideflate main()
                         'skipverify': False,
@@ -211,7 +212,7 @@ def generate_testfile(sourcefile,destfile,minsize):
 
 def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
     ''' Run command, and handle special cases '''
-    args = shlex.split(command)
+    args = shlex.split(command, posix=sys.platform != 'win32')
     if (silent == 1):
         devnull = open(output, 'w')
         retval = subprocess.call(args,env=env,stdout=devnull)

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -275,7 +275,9 @@ def runtest(tempfiles,level):
     # Compress
     printnn('c')
     starttime = time.perf_counter()
-    runcommand(f"{cmdprefix} ./{cfgRuns['testtool']} -{level} -c {testfile}", env=env, output=compfile)
+    testtool = os.path.realpath(cfgRuns['testtool'])
+
+    runcommand(f"{cmdprefix} {testtool} -{level} -c {testfile}", env=env, output=compfile)
     if sys.platform != 'win32':
         comptime = parse_timefile(timefile)
     else:
@@ -286,7 +288,7 @@ def runtest(tempfiles,level):
     if not cfgConfig['skipdecomp'] or not cfgConfig['skipverify']:
         printnn('d')
         starttime = time.perf_counter()
-        runcommand(f"{cmdprefix} ./{cfgRuns['testtool']} -d -c {compfile}", env=env, output=decompfile)
+        runcommand(f"{cmdprefix} {testtool} -d -c {compfile}", env=env, output=decompfile)
 
         if sys.platform != 'win32':
             decomptime = parse_timefile(timefile)


### PR DESCRIPTION
See #1 for previous discussions.

I have split the changes into multiple comments for this PR.

* Allow testtool argument to contain .exe extension for windows.
  * These changes also allow you to point to any executable as long as it starts with _minigzip_ or _minideflate_ which is useful.
* Set runcommand output default to os.devnull for cross-platform support.
* Don't run sync command when running on windows.
* Use time.perf_counter to calculate time spent compressing and decompressing on windows since prefixed commands don't exist
* Use tempfile to get cross-platform temporary directory.
* Allow absolute paths for testtool argument.
* Set high priority creation flag when creating process on Windows. (This does the same thing as `nice` command on linux)