### PR TITLE
Always show compressed size during each test run.

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -305,7 +305,7 @@ def runtest(tempfiles,level):
     os.unlink(timefile)
     os.unlink(compfile)
 
-    printnn(f" {comptime:.3f} {decomptime:.3f}")
+    printnn(f" {comptime:7.3f} {decomptime:7.3f} {compsize}")
     printnn('\n')
 
     return compsize,comptime,decomptime,hashfail


### PR DESCRIPTION
This is useful when running incremental tests, so I don't let all the runs pass if there is a significant negative compression size change.