### PR TITLE
Don't calculate avg2 compress time if minlevel not zero.

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -404,9 +404,10 @@ def printreport(results, tempfiles):
     ### Totals
     # Compression
     avgcomppct = totcomppct/numlevels
-    avgcomppct2 = totcomppct2/(numlevels-1)
     avgcomptime = totcomptime/(numlevels*numresults)
-    avgcomptime2 = totcomptime2/((numlevels-1)*numresults)
+    if cfgRuns['minlevel'] == 0:
+        avgcomppct2 = totcomppct2/(numlevels-1)
+        avgcomptime2 = totcomptime2/((numlevels-1)*numresults)
 
     # Decompression
     if cfgConfig['skipdecomp']:


### PR DESCRIPTION
If `minlevel != 0` it is possible for `numlevels == 0` which results in a divide by zero error. The code below this change that references `avg2comptime` and `avgdecomptime2` both have this check around them.