### PR TITLE
Fixed profiles not working due to premature arg loading.

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -517,7 +517,7 @@ def main():
     parser = argparse.ArgumentParser(description='deflatebench - A zlib-ng benchmarking utility. Please see config file for more options.')
     parser.add_argument('-r','--runs', help='Number of benchmark runs.', type=int)
     parser.add_argument('-t','--trimworst', help='Trim the N worst runs per level.', type=int)
-    parser.add_argument('-p','--profile', help='Load config profile from config file: ~/deflatebench-[PROFILE].conf', type=argparse.FileType('r'))
+    parser.add_argument('-p','--profile', help='Load config profile from config file: ~/deflatebench-[PROFILE].conf')
     parser.add_argument('--write-config', help='Write default configfile to ~/deflatebench.conf.', action='store_true')
     parser.add_argument('-s','--single', help='Activate testmode "Single"', action='store_true')
     parser.add_argument('-m','--multi', help='Activate testmode "Multi".', action='store_true')


### PR DESCRIPTION
It seems that profile must exist in order to validate the arg (because argparse attempts to open the file). However down below where profile is actually loaded, it constructs the name of the file `deflatebench-{profile}.conf`. So you can't pass in the full name and then you can't pass in a partial name. So this PR fixes it so you can pass in the partial name.