### PR TITLE
Fixed call to subprocess.call with empty dict fails on Windows

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -224,6 +224,7 @@ def generate_testfile(sourcefile,destfile,minsize):
 
 def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
     ''' Run command, and handle special cases '''
+    env = env if env else None
     args = shlex.split(command, posix=sys.platform != 'win32')
     sp_args = {}
     if sys.platform == 'win32':


### PR DESCRIPTION
Using Python 3.9.
```
  OSError: [WinError 87] The parameter is incorrect.
```
This is because `get_env` initializes with `env = dict()`. I am not using a deflatebench.conf for this setup and passing everything via command line which may have something to do with it, but maybe not.