### PR TITLE
Split config and utils functions into separate includefiles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+    zlib license
+    ------------
+
+    This software is provided 'as-is', without any express or implied
+    warranty. In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+       claim that you wrote the original software. If you use this software
+       in a product, an acknowledgment in the product documentation would be
+       appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+       misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -1,251 +1,25 @@
 #!/usr/bin/python3 -OOB
 """ deflatebench.py -- A util that benchmarks minigzip/minideflate.
 
-    Copyright (C) 2016-2020 Hans Kristian Rosbach
+    Copyright (C) Hans Kristian Rosbach
 
-    This software is provided 'as-is', without any express or implied
-    warranty. In no event will the authors be held liable for any damages
-    arising from the use of this software.
-
-    Permission is granted to anyone to use this software for any purpose,
-    including commercial applications, and to alter it and redistribute it
-    freely, subject to the following restrictions:
-
-    1. The origin of this software must not be misrepresented; you must not
-       claim that you wrote the original software. If you use this software
-       in a product, an acknowledgment in the product documentation would be
-       appreciated but is not required.
-    2. Altered source versions must be plainly marked as such, and must not be
-       misrepresented as being the original software.
-    3. This notice may not be removed or altered from any source distribution.
+    This software is provided under the Zlib License.
+    See the included LICENSE file for details.
 """
 
 import os, os.path
 import sys
-import re
-import math
-import tempfile
 import time
-import toml
-import shlex
 import shutil
-import hashlib
 import argparse
-import subprocess
 import statistics
-import platform
+
+from includes import cli
+from includes import config
+from includes import util
 
 # Simple usleep function
 usleep = lambda x: time.sleep(x/1000000.0)
-
-BUF_SIZE = 1024*1024  # lets read stuff in 1MB chunks when hashing or copying
-
-# ANSI color codes
-BLUE = '\033[34m'
-GREEN = '\033[32m'
-RED = '\033[31m'
-BRIGHT = '\033[1m'
-DIM = '\033[2m'
-RESET = '\033[0m'
-
-strip_ANSI_regex = re.compile(r"""
-    \x1b     # literal ESC
-    \[       # literal [
-    [;\d]*   # zero or more digits or semicolons
-    [A-Za-z] # a letter
-    """, re.VERBOSE).sub
-
-def get_len(s):
-    ''' Return string length excluding ANSI escape strings '''
-    return len(strip_ANSI_regex("", s))
-
-def padstr(instr, length, left=False):
-    ''' Build string pad to length '''
-    padstr = ' ' * (length - get_len(instr))
-    return f"{padstr}{instr}" if not left else f"{instr}{padstr}"
-
-def resultstr(result,totlen):
-    ''' Build result string and pad to totlen'''
-    tmpr = ( f"{BLUE}{result['mintime']:.4f}{RESET}"
-             f"/{GREEN}{result['avgtime']:.4f}{RESET}"
-             f"/{RED}{result['maxtime']:.4f}{RESET}"
-             f"/{BRIGHT}{result['stddev']:.4f}{RESET}" )
-    return padstr(tmpr, totlen)
-
-def printnn(text):
-    ''' Print without causing a newline '''
-    sys.stdout.write(text)
-    sys.stdout.flush()
-
-def defconfig():
-    ''' Define default config '''
-    config = dict()
-    config['Testruns'] = {  'runs': 15,
-                            'trimworst': 5,
-                            'minlevel': 0,
-                            'maxlevel': 9,
-                            'strategies': '', # fhRF
-                            'testmode': 'single',  # generate / multi / single
-                            'testtool': 'minigzip' } # minigzip / minideflate
-
-    config['Config'] = {'temp_path': tempfile.gettempdir(),
-                        'use_perf': True,
-                        'start_delay': 0,   # Milliseconds of startup to skip measuring, requires usleep(X*1000) in minigzip/minideflate main()
-                        'skipverify': False,
-                        'skipdecomp': False}
-
-    ## CPU related settings
-    config['Tuning'] = {'use_chrt': False,
-                        'use_nosync': False,
-                        'use_turboctl': False,
-                        'use_cpupower': False,
-                        'cpu_std_minspeed': 1000,
-                        'cpu_std_maxspeed': 2200,
-                        'cpu_bench_speed': 2000 }
-
-    # Single testfile
-    config['Testdata_Single'] = { 'testfile': 'silesia.tar' }
-
-    # Multiple testfiles
-    config['Testdata_Multi'] = {'0': 'testfile-500M',
-                                '1': 'testfile-300M',
-                                '2': 'testfile-150M',
-                                '3': 'testfile-125M',
-                                '4': 'testfile-100M',
-                                '5': 'testfile-85M',
-                                '6': 'testfile-75M',
-                                '7': 'testfile-40M',
-                                '8': 'testfile-20M',
-                                '9': 'testfile-20M' }
-
-    # Generated testfiles
-    config['Testdata_Gen'] =  { 'srcFile': 'silesia-small.tar',
-                                '0': 500,
-                                '1': 270,
-                                '2': 135,
-                                '3': 105,
-                                '4': 90,
-                                '5': 90,
-                                '6': 75,
-                                '7': 60,
-                                '8': 45,
-                                '9': 45 }
-    return config
-
-def parseconfig(file):
-    ''' Parse config file '''
-    config = toml.load(file)
-    return config
-
-def writeconfig(file):
-    ''' Write default config to file '''
-    config = defconfig()
-    with open(file, 'w') as f:
-        toml.dump(config,f)
-
-def mergeconfig(src, chg):
-    ''' Merge config settings from chg into src '''
-    if 'Testruns' in chg:
-        src['Testruns'].update(chg['Testruns'])
-    if 'Config' in chg:
-        src['Config'].update(chg['Config'])
-    if 'Tuning' in chg:
-        src['Tuning'].update(chg['Tuning'])
-    if 'Testdata_Gen' in chg:
-        src['Testdata_Gen'].update(chg['Testdata_Gen'])
-    if 'Testdata_Single' in chg:
-        src['Testdata_Single'].update(chg['Testdata_Single'])
-    if 'Testdata_Multi' in chg:
-        src['Testdata_Multi'].update(chg['Testdata_Multi'])
-    return src
-
-def cputweak(enable):
-    ''' Disable turbo, disable idlestates, and set fixed cpu mhz. Requires sudo rights. '''
-    # Turn off cpu turbo and power savings
-    if enable:
-        if cfgTuning['use_turboctl']:
-            runcommand('sudo /usr/bin/turboctl off', silent=1)
-        if cfgTuning['use_cpupower']:
-            runcommand(f"sudo /usr/bin/cpupower frequency-set -g performance --min {cfgTuning['cpu_bench_speed']*1000} --max {cfgTuning['cpu_bench_speed']*1000}", silent=1)
-            runcommand('sudo /usr/bin/cpupower idle-set -D 2', silent=1)
-
-    # Turn cpu turbo and power savings back on
-    if not enable:
-        if cfgTuning['use_turboctl']:
-            runcommand('sudo /usr/bin/turboctl on')
-        if cfgTuning['use_cpupower']:
-            runcommand(f"sudo /usr/bin/cpupower frequency-set --min {cfgTuning['cpu_std_minspeed']*1000} --max {cfgTuning['cpu_std_maxspeed']*1000}")
-            runcommand('sudo /usr/bin/cpupower idle-set -E')
-
-def findfile(filename,fatal=True):
-    ''' Search for filename in CWD, homedir and deflatebench.py-dir '''
-    filepath = os.path.dirname(os.path.realpath(__file__))
-    tmpCwd = os.path.join( os.getcwd(), filename)
-    tmpHome = os.path.join( os.path.expanduser("~"), filename)
-    tmpScript = os.path.join(filepath, filename)
-    if os.path.isfile(tmpCwd):
-        return os.path.realpath(tmpCwd)
-    elif os.path.isfile(tmpHome):
-        return os.path.realpath(tmpHome)
-    elif os.path.isfile(tmpScript):
-        return os.path.realpath(tmpScript)
-
-    if fatal:
-        print(f"Unable to find file: '{filename}'")
-        sys.exit(1)
-    return None
-
-def hashfile(file):
-    ''' Calculate hash of file '''
-    sha1 = hashlib.sha1()
-
-    with open(file, 'rb') as f:
-        while True:
-            data = f.read(BUF_SIZE)
-            if not data:
-                break
-            sha1.update(data)
-    return sha1.hexdigest()
-
-def generate_testfile(sourcefile,destfile,minsize):
-    ''' Make tempfiles that are concatenated repeatedly until the file is big enough '''
-    srcsize = os.path.getsize(sourcefile)
-    count = math.ceil((minsize*1024*1024)/srcsize)
-    dstsize = srcsize*count
-
-    dst = open(destfile, "wb")
-    with open(sourcefile, 'rb') as src:
-        while os.path.getsize(destfile) < dstsize:
-            data = src.read(BUF_SIZE)
-            if not data:
-                src.seek(0)
-                continue
-            dst.write(data)
-    dst.close()
-
-def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
-    ''' Run command, and handle special cases '''
-    env = env if env else None
-    args = shlex.split(command, posix=sys.platform != 'win32')
-    sp_args = {}
-    if sys.platform == 'win32':
-        sp_args['creationflags'] = subprocess.HIGH_PRIORITY_CLASS
-    if silent == 1:
-        devnull = open(output, 'w')
-        retval = subprocess.call(args,env=env,stdout=devnull,**sp_args)
-        devnull.close()
-    else:
-        retval = subprocess.call(args,env=env,**sp_args)
-    if (retval != 0) and (stoponfail != 0):
-        sys.exit(f"Failed, retval({retval}): {command}")
-    return retval
-
-def get_env(bench=False):
-    ''' Build dict of environment variables '''
-    env = dict()
-    if bench and cfgTuning['use_nosync']:
-        env['LD_PRELOAD'] = '/usr/lib64/nosync/nosync.so'
-    return env
 
 def command_prefix(filen):
     ''' Build the benchmarking command prefix '''
@@ -262,20 +36,6 @@ def command_prefix(filen):
 
     return command
 
-def parse_timefile(filen):
-    ''' Parse output from perf or time '''
-    if cfgConfig['use_perf']:
-        with open(filen) as f:
-            content = f.readlines()
-        for line in content:
-            if line[-13:-1] == 'seconds user':
-                return float(line[:-13])
-        return 0.0
-    else:
-        with open(filen) as f:
-            content = f.readlines()
-        return float(content[0])
-
 def runtest(tempfiles,level):
     ''' Run benchmark and tests for current compression level'''
     hashfail, decomptime = 0,0
@@ -283,40 +43,40 @@ def runtest(tempfiles,level):
     orighash = tempfiles[level]['hash']
     cmdprefix = ''
 
-    env = get_env(True)
+    env = util.get_env(True)
 
     sys.stdout.write(f"Testing level {level}: ")
     if sys.platform != 'win32':
         cmdprefix = command_prefix(timefile)
-        runcommand('sync')
+        util.runcommand('sync')
 
     # Compress
-    printnn('c')
+    cli.printnn('c')
     usleep(10)
     starttime = time.perf_counter()
     testtool = os.path.realpath(cfgRuns['testtool'])
 
-    runcommand(f"{cmdprefix} {testtool} -{level} -c {testfile}", env=env, output=compfile)
+    util.runcommand(f"{cmdprefix} {testtool} -{level} -c {testfile}", env=env, output=compfile)
     if sys.platform != 'win32':
-        comptime = parse_timefile(timefile)
+        comptime = util.parse_timefile(timefile)
     else:
         comptime = time.perf_counter() - starttime
     compsize = os.path.getsize(compfile)
 
     # Decompress
     if not cfgConfig['skipdecomp'] or not cfgConfig['skipverify']:
-        printnn('d')
+        cli.printnn('d')
         usleep(10)
         starttime = time.perf_counter()
-        runcommand(f"{cmdprefix} {testtool} -d -c {compfile}", env=env, output=decompfile)
+        util.runcommand(f"{cmdprefix} {testtool} -d -c {compfile}", env=env, output=decompfile)
 
         if sys.platform != 'win32':
-            decomptime = parse_timefile(timefile)
+            decomptime = util.parse_timefile(timefile)
         else:
             decomptime = time.perf_counter() - starttime
 
         if not cfgConfig['skipverify']:
-            ourhash = hashfile(decompfile)
+            ourhash = util.hashfile(decompfile)
             if ourhash != orighash:
                 print(f"{orighash} != {ourhash}")
                 hashfail = 1
@@ -325,10 +85,10 @@ def runtest(tempfiles,level):
 
     # Validate using gunzip
     if not cfgConfig['skipverify']:
-        printnn('v')
-        runcommand(f"gunzip -c {compfile}", output=decompfile)
+        cli.printnn('v')
+        util.runcommand(f"gunzip -c {compfile}", output=decompfile)
 
-        gziphash = hashfile(decompfile)
+        gziphash = util.hashfile(decompfile)
         if gziphash != orighash:
             print(f"{orighash} != {gziphash}")
             hashfail = 1
@@ -340,8 +100,8 @@ def runtest(tempfiles,level):
     os.unlink(compfile)
 
     comppct = float(compsize*100)/tempfiles[level]['origsize']
-    printnn(f" {comptime:7.4f} {decomptime:7.4f} {compsize:15,} {comppct:7.3f}%")
-    printnn('\n')
+    cli.printnn(f" {comptime:7.4f} {decomptime:7.4f} {compsize:15,} {comppct:7.3f}%")
+    cli.printnn('\n')
 
     return compsize,comptime,decomptime,hashfail
 
@@ -457,18 +217,13 @@ def calculate(results, tempfiles):
 
     return res_comp, res_decomp, res_totals
 
-def printinfo():
-    uname = platform.uname()
-    print(f"OS: {uname.system} {uname.release} {uname.version} {uname.machine}")
-    print(f"CPU: {platform.processor()}")
-    print(f"Tool: {cfgRuns['testtool']} Size: {os.path.getsize(cfgRuns['testtool']):,} B")
-
 def printreport(comp,decomp,totals):
     ''' Print results table '''
     # Print config info
 
     print("\n")
-    printinfo()
+    util.printsysinfo()
+    print(f"Tool: {cfgRuns['testtool']} Size: {os.path.getsize(cfgRuns['testtool']):,} B")
     levelrange = f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}"
     print(f"Levels: {levelrange:10}")
     print(f"Runs: {str(cfgRuns['runs']):10} Trim worst: {str(cfgRuns['trimworst']):10}")
@@ -481,10 +236,10 @@ def printreport(comp,decomp,totals):
 
     for level in map(str, getlevels()):
         # Print level results
-        compstr = resultstr(comp[level],28)
+        compstr = cli.resultstr(comp[level],28)
         decompstr = ""
         if not cfgConfig['skipdecomp']:
-            decompstr = resultstr(decomp[level],30)
+            decompstr = cli.resultstr(decomp[level],30)
 
         print(f" {level:5}{comp[level]['avgpct']:7.3f}% {compstr} {decompstr}  {comp[level]['compsize']:15,}")
 
@@ -507,7 +262,8 @@ def benchmain():
     ''' Main benchmarking function '''
     global timefile, compfile, decompfile
 
-    printinfo()
+    util.printsysinfo()
+    print(f"Tool: {cfgRuns['testtool']} Size: {os.path.getsize(cfgRuns['testtool']):,} B")
 
     # Prepare tempfiles
     timefile = os.path.join(cfgConfig['temp_path'], 'zlib-time.tmp')
@@ -519,9 +275,9 @@ def benchmain():
     # Single testfile, we just reference the same file for every level
     if cfgRuns['testmode'] == 'single':
         tmp_filename = os.path.join(cfgConfig['temp_path'], "deflatebench.tmp")
-        srcfile = findfile(cfgSingle['testfile'])
+        srcfile = util.findfile(cfgSingle['testfile'])
         shutil.copyfile(srcfile,tmp_filename)
-        tmp_hash = hashfile(tmp_filename)
+        tmp_hash = util.hashfile(tmp_filename)
         origsize = os.path.getsize(tmp_filename)
         print("Activated single file mode")
         printfile(f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}", srcfile)
@@ -544,18 +300,18 @@ def benchmain():
             tempfiles[level]['filename'] = tmp_filename
 
             if cfgRuns['testmode'] == 'multi':
-                srcfile = findfile(cfgMulti[level])
+                srcfile = util.findfile(cfgMulti[level])
                 shutil.copyfile(srcfile,tmp_filename)
                 printfile(f"{level}", srcfile)
             else:
-                generate_testfile(findfile(cfgGen['srcFile']),tmp_filename,cfgGen[level])
+                util.generate_testfile(util.findfile(cfgGen['srcFile']),tmp_filename,cfgGen[level])
                 printfile(f"{level}", tmp_filename)
 
-            tempfiles[level]['hash'] = hashfile(tmp_filename)
+            tempfiles[level]['hash'] = util.hashfile(tmp_filename)
             tempfiles[level]['origsize'] = os.path.getsize(tmp_filename)
 
     # Tweak system to reduce benchmark variance
-    cputweak(True)
+    util.cputweak(True)
 
     # Prepare multilevel results array
     results = dict()
@@ -578,7 +334,7 @@ def benchmain():
     printreport(res_comp,res_decomp,res_totals)
 
     # Disable system tweaks to restore normal powersaving, turbo, etc
-    cputweak(False)
+    util.cputweak(False)
 
     # Clean up tempfiles
     for level in map(str, getlevels()):
@@ -602,29 +358,29 @@ def main():
     parser.add_argument('--skipverify', help='Skip verifying compressed files with system gzip.', action='store_true')
     args = parser.parse_args()
 
-    defconfig_path = findfile('deflatebench.conf',fatal=False)
+    defconfig_path = util.findfile('deflatebench.conf',fatal=False)
 
     # Write default config file
     if args.write_config:
         if not defconfig_path:
             defconfig_path = os.path.join( os.path.expanduser("~"), 'deflatebench.conf')
-            writeconfig(defconfig_path)
+            config.writeconfig(defconfig_path)
         else:
             print(f"ERROR: {defconfig_path} already exists, not overwriting.")
         sys.exit(1)
 
 
     # Load defconfig, then potentially override with values from config file
-    cfg = defconfig()
+    cfg = config.defconfig()
     if args.profile and not args.profile == 'default':
         profilename = f"deflatebench-{args.profile}.conf"
-        profilefile = findfile(profilename, fatal=True)
-        cfgtmp = parseconfig(profilefile)
-        cfg = mergeconfig(cfg,cfgtmp)
+        profilefile = util.findfile(profilename, fatal=True)
+        cfgtmp = config.parseconfig(profilefile)
+        cfg = config.mergeconfig(cfg,cfgtmp)
         print(f"Loaded config file '{profilefile}'.")
     elif defconfig_path:
-        cfgtmp = parseconfig(defconfig_path)
-        cfg = mergeconfig(cfg,cfgtmp)
+        cfgtmp = config.parseconfig(defconfig_path)
+        cfg = config.mergeconfig(cfg,cfgtmp)
         print(f"Loaded config file '{defconfig_path}'.")
     else:
         print("Loaded default config.")
@@ -636,6 +392,8 @@ def main():
     cfgGen = cfg['Testdata_Gen']
     cfgSingle = cfg['Testdata_Single']
     cfgMulti = cfg['Testdata_Multi']
+
+    util.init(cfgConfig, cfgTuning)
 
     # Handle commandline parameters
     if args.runs is not None:

--- a/includes/cli.py
+++ b/includes/cli.py
@@ -1,0 +1,47 @@
+""" cli.py -- Helperfunctions for formatting cli output.
+
+    Copyright (C) Hans Kristian Rosbach
+
+    This software is provided under the Zlib License.
+    See the included LICENSE file for details.
+"""
+
+import re
+import sys
+
+# ANSI color codes
+BLUE = '\033[34m'
+GREEN = '\033[32m'
+RED = '\033[31m'
+BRIGHT = '\033[1m'
+DIM = '\033[2m'
+RESET = '\033[0m'
+
+strip_ANSI_regex = re.compile(r"""
+    \x1b     # literal ESC
+    \[       # literal [
+    [;\d]*   # zero or more digits or semicolons
+    [A-Za-z] # a letter
+    """, re.VERBOSE).sub
+
+def get_len(s):
+    ''' Return string length excluding ANSI escape strings '''
+    return len(strip_ANSI_regex("", s))
+
+def padstr(instr, length, left=False):
+    ''' Build string pad to length '''
+    padstr = ' ' * (length - get_len(instr))
+    return f"{padstr}{instr}" if not left else f"{instr}{padstr}"
+
+def resultstr(result,totlen):
+    ''' Build result string and pad to totlen'''
+    tmpr = ( f"{BLUE}{result['mintime']:.4f}{RESET}"
+             f"/{GREEN}{result['avgtime']:.4f}{RESET}"
+             f"/{RED}{result['maxtime']:.4f}{RESET}"
+             f"/{BRIGHT}{result['stddev']:.4f}{RESET}" )
+    return padstr(tmpr, totlen)
+
+def printnn(text):
+    ''' Print without causing a newline '''
+    sys.stdout.write(text)
+    sys.stdout.flush()

--- a/includes/config.py
+++ b/includes/config.py
@@ -1,0 +1,91 @@
+""" config.py -- Helperfunctions related to reading/writing deflatebench config files.
+
+    Copyright (C) Hans Kristian Rosbach
+
+    This software is provided under the Zlib License.
+    See the included LICENSE file for details.
+"""
+import tempfile
+import toml
+
+def defconfig():
+    ''' Define default config '''
+    config = dict()
+    config['Testruns'] = {  'runs': 15,
+                            'trimworst': 5,
+                            'minlevel': 0,
+                            'maxlevel': 9,
+                            'strategies': '', # fhRF
+                            'testmode': 'single',  # generate / multi / single
+                            'testtool': 'minigzip' } # minigzip / minideflate
+
+    config['Config'] = {'temp_path': tempfile.gettempdir(),
+                        'use_perf': True,
+                        'start_delay': 0,   # Milliseconds of startup to skip measuring, requires usleep(X*1000) in minigzip/minideflate main()
+                        'skipverify': False,
+                        'skipdecomp': False}
+
+    ## CPU related settings
+    config['Tuning'] = {'use_chrt': False,
+                        'use_nosync': False,
+                        'use_turboctl': False,
+                        'use_cpupower': False,
+                        'cpu_std_minspeed': 1000,
+                        'cpu_std_maxspeed': 2200,
+                        'cpu_bench_speed': 2000 }
+
+    # Single testfile
+    config['Testdata_Single'] = { 'testfile': 'silesia.tar' }
+
+    # Multiple testfiles
+    config['Testdata_Multi'] = {'0': 'testfile-500M',
+                                '1': 'testfile-300M',
+                                '2': 'testfile-150M',
+                                '3': 'testfile-125M',
+                                '4': 'testfile-100M',
+                                '5': 'testfile-85M',
+                                '6': 'testfile-75M',
+                                '7': 'testfile-40M',
+                                '8': 'testfile-20M',
+                                '9': 'testfile-20M' }
+
+    # Generated testfiles
+    config['Testdata_Gen'] =  { 'srcFile': 'silesia-small.tar',
+                                '0': 500,
+                                '1': 270,
+                                '2': 135,
+                                '3': 105,
+                                '4': 90,
+                                '5': 90,
+                                '6': 75,
+                                '7': 60,
+                                '8': 45,
+                                '9': 45 }
+    return config
+
+def parseconfig(file):
+    ''' Parse config file '''
+    config = toml.load(file)
+    return config
+
+def writeconfig(file):
+    ''' Write default config to file '''
+    config = defconfig()
+    with open(file, 'w') as f:
+        toml.dump(config,f)
+
+def mergeconfig(src, chg):
+    ''' Merge config settings from chg into src '''
+    if 'Testruns' in chg:
+        src['Testruns'].update(chg['Testruns'])
+    if 'Config' in chg:
+        src['Config'].update(chg['Config'])
+    if 'Tuning' in chg:
+        src['Tuning'].update(chg['Tuning'])
+    if 'Testdata_Gen' in chg:
+        src['Testdata_Gen'].update(chg['Testdata_Gen'])
+    if 'Testdata_Single' in chg:
+        src['Testdata_Single'].update(chg['Testdata_Single'])
+    if 'Testdata_Multi' in chg:
+        src['Testdata_Multi'].update(chg['Testdata_Multi'])
+    return src

--- a/includes/util.py
+++ b/includes/util.py
@@ -1,0 +1,135 @@
+""" util.py -- Selfcontained helperfunctions.
+
+    Copyright (C) Hans Kristian Rosbach
+
+    This software is provided under the Zlib License.
+    See the included LICENSE file for details.
+"""
+
+import os, os.path
+import sys
+import hashlib
+import math
+import platform
+import subprocess
+import shlex
+
+BUF_SIZE = 1024*1024  # lets read stuff in 1MB chunks when hashing or copying
+
+def init(inConfig, inTuning):
+    ''' Initialize variables '''
+    global cfgConfig, cfgTuning
+    cfgConfig = inConfig
+    cfgTuning = inTuning
+
+def get_env(bench=False):
+    ''' Build dict of environment variables '''
+    env = dict()
+    if bench and cfgTuning['use_nosync']:
+        env['LD_PRELOAD'] = '/usr/lib64/nosync/nosync.so'
+    return env
+
+def printsysinfo():
+    ''' Print system information '''
+    uname = platform.uname()
+    print(f"OS: {uname.system} {uname.release} {uname.version} {uname.machine}")
+    print(f"CPU: {platform.processor()}")
+
+def cputweak(enable):
+    ''' Disable turbo, disable idlestates, and set fixed cpu mhz. Requires sudo rights. '''
+    # Turn off cpu turbo and power savings
+    if enable:
+        if cfgTuning['use_turboctl']:
+            runcommand('sudo /usr/bin/turboctl off', silent=1)
+        if cfgTuning['use_cpupower']:
+            runcommand(f"sudo /usr/bin/cpupower frequency-set -g performance --min {cfgTuning['cpu_bench_speed']*1000} --max {cfgTuning['cpu_bench_speed']*1000}", silent=1)
+            runcommand('sudo /usr/bin/cpupower idle-set -D 2', silent=1)
+
+    # Turn cpu turbo and power savings back on
+    if not enable:
+        if cfgTuning['use_turboctl']:
+            runcommand('sudo /usr/bin/turboctl on')
+        if cfgTuning['use_cpupower']:
+            runcommand(f"sudo /usr/bin/cpupower frequency-set --min {cfgTuning['cpu_std_minspeed']*1000} --max {cfgTuning['cpu_std_maxspeed']*1000}")
+            runcommand('sudo /usr/bin/cpupower idle-set -E')
+
+def findfile(filename,fatal=True):
+    ''' Search for filename in CWD, homedir and deflatebench.py-dir '''
+    tmpCwd = os.path.normpath(os.path.join( os.getcwd(), filename))
+    tmpHome = os.path.normpath(os.path.join( os.path.expanduser("~"), filename))
+    filepath = os.path.dirname(os.path.realpath(__file__))
+    tmpScript = os.path.normpath(os.path.join(filepath, '../', filename))
+    if os.path.isfile(tmpCwd):
+        return os.path.realpath(tmpCwd)
+    elif os.path.isfile(tmpHome):
+        return os.path.realpath(tmpHome)
+    elif os.path.isfile(tmpScript):
+        return os.path.realpath(tmpScript)
+
+    if fatal:
+        print(f"Unable to find file: '{filename}'")
+        sys.exit(1)
+    return None
+
+def hashfile(file):
+    ''' Calculate hash of file '''
+    sha1 = hashlib.sha1()
+
+    with open(file, 'rb') as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            sha1.update(data)
+    return sha1.hexdigest()
+
+def generate_testfile(sourcefile,destfile,minsize):
+    ''' Make tempfiles that are concatenated repeatedly until the file is big enough '''
+    srcsize = os.path.getsize(sourcefile)
+    if srcsize == 0:
+        print(f"Error: Sourcefile '{sourcefile}' is empty, cannot generate testfiles.")
+        sys.exit(1)
+
+    count = math.ceil((minsize*1024*1024)/srcsize)
+    dstsize = srcsize*count
+
+    dst = open(destfile, "wb")
+    with open(sourcefile, 'rb') as src:
+        while os.path.getsize(destfile) < dstsize:
+            data = src.read(BUF_SIZE)
+            if not data:
+                src.seek(0)
+                continue
+            dst.write(data)
+    dst.close()
+
+def parse_timefile(filen):
+    ''' Parse output from perf or time '''
+    if cfgConfig['use_perf']:
+        with open(filen) as f:
+            content = f.readlines()
+        for line in content:
+            if line[-13:-1] == 'seconds user':
+                return float(line[:-13])
+        return 0.0
+    else:
+        with open(filen) as f:
+            content = f.readlines()
+        return float(content[0])
+
+def runcommand(command, env=None, stoponfail=1, silent=1, output=os.devnull):
+    ''' Run command, and handle special cases '''
+    env = env if env else None
+    args = shlex.split(command, posix=sys.platform != 'win32')
+    sp_args = {}
+    if sys.platform == 'win32':
+        sp_args['creationflags'] = subprocess.HIGH_PRIORITY_CLASS
+    if silent == 1:
+        devnull = open(output, 'w')
+        retval = subprocess.call(args,env=env,stdout=devnull,**sp_args)
+        devnull.close()
+    else:
+        retval = subprocess.call(args,env=env,**sp_args)
+    if (retval != 0) and (stoponfail != 0):
+        sys.exit(f"Failed, retval({retval}): {command}")
+    return retval


### PR DESCRIPTION
I have plans for adding multiple tools in addition to deflatebench, some would benefit from having access to some of the functionality already in deflatebench.
Therefore, I feel it is time to split deflatebench up from being monolitihic to be using modules.

This PR splits several functions into Cli, Config and Util modules and fixes up related code.
- Cli contains functions that help with formatting cli output.
- Config could be made into a full-fledged module in time.
- Util contains functions that are pretty much self-contained and potentially useful elsewhere (cputweak currently depends on the config, so not really a good fit, and might in time get its own module possibly along with improved portability).

Also add separate LICENSE file so we don't have to include the license in every file.