### PR TITLE
Add decompress only, and refactor compute & results printing

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -18,6 +18,8 @@ from includes import cli
 from includes import config
 from includes import util
 
+from includes.cli import printnn
+
 def trimworst(results):
     ''' Trim X worst results '''
     results.sort()
@@ -36,8 +38,7 @@ def calculate(results, tempfiles):
     totsize, totsize2 = [0]*2
     totcomppct, totcomppct2 = [0]*2
     totcomptime, totcomptime2 = [0]*2
-    totdecomptime, totdecomptime2 = [0]*2
-    res_comp, res_decomp, res_totals = dict(), dict(), dict()
+    res_comp, res_totals = dict(), dict()
 
     numresults = cfgRuns['runs'] - cfgRuns['trimworst']
     numlevels = len(getlevels())
@@ -45,16 +46,14 @@ def calculate(results, tempfiles):
     # Calculate and print stats per level
     for level in map(str, getlevels()):
         origsize = tempfiles[level]['origsize']
-        comp, decomp = dict(), dict()
+        comp = dict()
 
         # Find best/worst times for this level
         comp['compsize'] = None
         rawcomptimes = []
-        rawdecomptimes = []
         for run in results[level]:
-            rsize,rcompt,rdecompt = run
+            rsize,rcompt = run
             rawcomptimes.append(rcompt)
-            rawdecomptimes.append(rdecompt)
             if comp['compsize'] is not None and comp['compsize'] != rsize:
                 print(f"Warning: size changed between runs. Expected: {comp['compsize']} Got: {rsize}")
             else:
@@ -62,73 +61,49 @@ def calculate(results, tempfiles):
 
         # Trim the worst results
         comptimes = trimworst(rawcomptimes)
-        decomptimes = trimworst(rawdecomptimes)
 
         # Compute averages
-        comp['avgtime']   = statistics.mean(comptimes)
-        decomp['avgtime'] = statistics.mean(decomptimes)
+        comp['avgtime'] = statistics.mean(comptimes)
         comp['avgpct'] = float(rsize*100)/origsize
 
         # Compute stddev
         if numresults >= 2:
-            comp['stddev']   = statistics.stdev(comptimes, comp['avgtime'])
-            decomp['stddev'] = statistics.stdev(decomptimes, decomp['avgtime'])
+            comp['stddev'] = statistics.stdev(comptimes, comp['avgtime'])
         else:
-            comp['stddev']   = 0
-            decomp['stddev'] = 0
+            comp['stddev'] = 0
 
         # Calculate min/max and sum for this level
         comp['mintime']   = min(comptimes)
         comp['maxtime']   = max(comptimes)
-        decomp['mintime'] = min(decomptimes)
-        decomp['maxtime'] = max(decomptimes)
 
         # Store values for grand total
         tmp_comptime = sum(comptimes)
-        tmp_decomptime = sum(decomptimes)
 
         totsize += rsize
         totcomppct += comp['avgpct']
         totcomptime += tmp_comptime
-        totdecomptime += tmp_decomptime
         if level != 0:
             totsize2 += rsize
             totcomppct2 += comp['avgpct']
             totcomptime2 += tmp_comptime
-            totdecomptime2 += tmp_decomptime
 
         # Put this levels results into the aggregate
         res_comp[level] = dict(comp.items())
-        res_decomp[level] = dict(decomp.items())
 
     ### Totals
     res_totals['numresults'] = numresults
     res_totals['numlevels'] = numlevels
     res_totals['totsize'] = totsize
 
-    # Compression
-    res_totals['totcomptime'] = totcomptime
-    res_totals['avgcomppct'] = totcomppct/numlevels
-    res_totals['avgcomptime'] = totcomptime/(numlevels*numresults)
+    # Averages/Totals
+    res_totals['tottime'] = totcomptime
+    res_totals['avgpct'] = totcomppct/numlevels
+    res_totals['avgtime'] = totcomptime/(numlevels*numresults)
     if cfgRuns['minlevel'] == 0:
-        res_totals['avgcomppct2'] = totcomppct2/(numlevels-1)
-        res_totals['avgcomptime2'] = totcomptime2/((numlevels-1)*numresults)
+        res_totals['avgpct2'] = totcomppct2/(numlevels-1)
+        res_totals['avgtime2'] = totcomptime2/((numlevels-1)*numresults)
 
-    # Decompression
-    if not do_decompress:
-        res_totals['totdecomptime'] = totdecomptime
-        res_totals['avgdecomptime'], res_totals['avgdecompstr'], res_totals['totdecompstr'] = [''] * 3
-        res_totals['avgdecomptime2'], res_totals['avgdecompstr2'], res_totals['totdecompstr2'] = [''] * 3
-    else:
-        res_totals['avgdecomptime'] = totdecomptime/(res_totals['numlevels'] * res_totals['numresults'])
-        res_totals['avgdecompstr'] = f"{res_totals['avgdecomptime']:.4f}"
-        res_totals['totdecompstr'] = f"{totdecomptime:.4f}"
-        if cfgRuns['minlevel'] == 0:
-            res_totals['avgdecomptime2'] = totdecomptime2/((res_totals['numlevels'] - 1) * res_totals['numresults'])
-            res_totals['avgdecompstr2'] = f"{res_totals['avgdecomptime2']:.4f}"
-            res_totals['totdecompstr2'] = f"{totdecomptime2:.4f}"
-
-    return res_comp, res_decomp, res_totals
+    return res_comp, res_totals
 
 def printinfo():
     ''' Prints system and configuration info '''
@@ -141,44 +116,50 @@ def printinfo():
     print(f"Runs: {str(cfgRuns['runs']):10} Trim worst: {str(cfgRuns['trimworst']):10}")
     print("")
 
-def printreport(comp,decomp,totals):
-    ''' Print results table '''
-    # Print header
-    if not do_compress:
-        print(" Level   Comp    Decomptime min/avg/max/stddev  Compressed size")
-    elif not do_decompress:
-        print(" Level   Comp   Comptime min/avg/max/stddev   Compressed size")
+def print_resultline(header,pct,comp,decomp,size=None):
+    printnn(f" {header:5}")
+    if isinstance(pct, float):
+        printnn(f"{pct:>7.3f}% ")
     else:
-        print(" Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size")
+        printnn(f"{pct:>8} ")
+    if do_compress:
+        printnn(f"{comp:>28} ")
+    if do_decompress:
+        printnn(f"{decomp:>30} ")
+    if size is not None:
+        printnn(f" {size:15}")
+    print('')
 
+def printreport(comp,decomp,comp_tot,decomp_tot):
+    ''' Print results table '''
+    # Little hack to provide results that we can then ignore, simplifies the code
+    if not do_compress:
+        comp = decomp
+        comp_tot = decomp_tot
+    elif not do_decompress:
+        decomp = comp
+        decomp_tot = comp_tot
+
+    # Print header
+    print_resultline('Level', 'Comp', 'Comptime min/avg/max/stddev', 'Decomptime min/avg/max/stddev', 'Compressed size')
+
+    # Print level results
     for level in map(str, getlevels()):
-        # Print level results
-        compstr = ""
-        decompstr = ""
+        compstr, decompstr = '', ''
 
         if do_compress:
             compstr = cli.resultstr(comp[level],28)
         if do_decompress:
             decompstr = cli.resultstr(decomp[level],30)
 
-        print(f" {level:5}{comp[level]['avgpct']:7.3f}% {compstr} {decompstr}  {comp[level]['compsize']:15,}")
+        print_resultline(level, comp[level]['avgpct'], compstr, decompstr, comp[level]['compsize'])
 
     # Print totals
-    if not do_decompress:
-        print(f"\n {'avg1':5}{totals['avgcomppct']:7.3f}%  {totals['avgdecompstr']:>30}")
-        if cfgRuns['minlevel'] == 0:
-            print(f" {'avg2':5}{totals['avgcomppct2']:7.3f}%  {totals['avgdecompstr2']:>30}")
-
-        print(f" {'tot':5}  {'':8}{totals['totdecompstr']:>30}  {totals['totsize']:15,}")
-    else:
-        print(f"\n {'avg1':5}{totals['avgcomppct']:7.3f}% {totals['avgcomptime']:28.4f} {totals['avgdecompstr']:>30}")
-        if cfgRuns['minlevel'] == 0:
-            print(f" {'avg2':5}{totals['avgcomppct2']:7.3f}% {totals['avgcomptime2']:28.4f} {totals['avgdecompstr2']:>30}")
-
-        if not do_decompress:
-            print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f}   {totals['totsize']:15,}")
-        else:
-            print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f} {totals['totdecompstr']:>30}  {totals['totsize']:15,}")
+    print('')
+    print_resultline('avg1', comp_tot['avgpct'], f"{comp_tot['avgtime']:.4f}", f"{decomp_tot['avgtime']:.4f}")
+    if cfgRuns['minlevel'] == 0:
+        print_resultline('avg2', comp_tot['avgpct2'], f"{comp_tot['avgtime2']:.4f}", f"{decomp_tot['avgtime2']:.4f}")
+    print('')
 
 def benchmain():
     ''' Main benchmarking function '''
@@ -245,13 +226,15 @@ def benchmain():
     util.cputweak(True)
 
     # Prepare multilevel results array
-    results = dict()
+    calc_comp, calc_comptot, calc_decomp, calc_decomptot = None, None, None, None
+    result_comp, result_decomp = dict(), dict()
     for level in map(str, getlevels()):
-        results[level] = []
+        result_comp[level] = []
+        result_decomp[level] = []
 
     # Prepare compressed files when only benchmarking decompress
     if not do_compress and cfgRuns['testmode'] != 'multi':
-        cli.printnn("Compressing tempfiles for decompression test ")
+        printnn("Compressing tempfiles for decompression test ")
         if cfgRuns['testmode'] == 'single':
             srcfile = cfgSingle['testfile']
         else: # gen
@@ -263,7 +246,8 @@ def benchmain():
             tmp_compfile = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile)}-{level}.gz")
             util.runcommand(f"{testtool} -{level} -c {tempfiles[level]['filename']}", output=tmp_compfile)
             tempfiles[level]['filename'] = tmp_compfile
-            cli.printnn('.')
+            printnn('.')
+        print('')
 
     # Run tests and record results
     for run in range(1,cfgRuns['runs']+1):
@@ -277,12 +261,18 @@ def benchmain():
                                                                       cfgConfig['skipverify'])
             if hashfail != 0:
                 print(f"ERROR: level {level} failed crc checking")
-            results[level].append( [compsize,comptime,decomptime] )
+            if do_compress:
+                result_comp[level].append( [compsize,comptime] )
+            if do_decompress:
+                result_decomp[level].append( [compsize,decomptime] )
 
-    res_comp,res_decomp,res_totals = calculate(results, tempfiles)
+    if do_compress:
+        calc_comp,calc_comptot = calculate(result_comp, tempfiles)
+    if do_decompress:
+        calc_decomp,calc_decomptot = calculate(result_decomp, tempfiles)
 
     printinfo()
-    printreport(res_comp,res_decomp,res_totals)
+    printreport(calc_comp,calc_decomp,calc_comptot,calc_decomptot)
 
     # Disable system tweaks to restore normal powersaving, turbo, etc
     util.cputweak(False)

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -115,7 +115,7 @@ def calculate(results, tempfiles):
         res_totals['avgcomptime2'] = totcomptime2/((numlevels-1)*numresults)
 
     # Decompression
-    if cfgConfig['skipdecomp']:
+    if not do_decompress:
         res_totals['totdecomptime'] = totdecomptime
         res_totals['avgdecomptime'], res_totals['avgdecompstr'], res_totals['totdecompstr'] = [''] * 3
         res_totals['avgdecomptime2'], res_totals['avgdecompstr2'], res_totals['totdecompstr2'] = [''] * 3
@@ -144,43 +144,61 @@ def printinfo():
 def printreport(comp,decomp,totals):
     ''' Print results table '''
     # Print header
-    if cfgConfig['skipdecomp']:
+    if not do_compress:
+        print(" Level   Comp    Decomptime min/avg/max/stddev  Compressed size")
+    elif not do_decompress:
         print(" Level   Comp   Comptime min/avg/max/stddev   Compressed size")
     else:
         print(" Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size")
 
     for level in map(str, getlevels()):
         # Print level results
-        compstr = cli.resultstr(comp[level],28)
+        compstr = ""
         decompstr = ""
-        if not cfgConfig['skipdecomp']:
+
+        if do_compress:
+            compstr = cli.resultstr(comp[level],28)
+        if do_decompress:
             decompstr = cli.resultstr(decomp[level],30)
 
         print(f" {level:5}{comp[level]['avgpct']:7.3f}% {compstr} {decompstr}  {comp[level]['compsize']:15,}")
 
     # Print totals
-    print(f"\n {'avg1':5}{totals['avgcomppct']:7.3f}% {totals['avgcomptime']:28.4f} {totals['avgdecompstr']:>30}")
-    if cfgRuns['minlevel'] == 0:
-        print(f" {'avg2':5}{totals['avgcomppct2']:7.3f}% {totals['avgcomptime2']:28.4f} {totals['avgdecompstr2']:>30}")
+    if not do_decompress:
+        print(f"\n {'avg1':5}{totals['avgcomppct']:7.3f}%  {totals['avgdecompstr']:>30}")
+        if cfgRuns['minlevel'] == 0:
+            print(f" {'avg2':5}{totals['avgcomppct2']:7.3f}%  {totals['avgdecompstr2']:>30}")
 
-    if cfgConfig['skipdecomp']:
-        print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f}   {totals['totsize']:15,}")
+        print(f" {'tot':5}  {'':8}{totals['totdecompstr']:>30}  {totals['totsize']:15,}")
     else:
-        print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f} {totals['totdecompstr']:>30}  {totals['totsize']:15,}")
+        print(f"\n {'avg1':5}{totals['avgcomppct']:7.3f}% {totals['avgcomptime']:28.4f} {totals['avgdecompstr']:>30}")
+        if cfgRuns['minlevel'] == 0:
+            print(f" {'avg2':5}{totals['avgcomppct2']:7.3f}% {totals['avgcomptime2']:28.4f} {totals['avgdecompstr2']:>30}")
 
-def printfile(level,filename):
-    ''' Prints formatted information about file '''
-    filesize = os.path.getsize(filename)
-    print(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
+        if not do_decompress:
+            print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f}   {totals['totsize']:15,}")
+        else:
+            print(f" {'tot':5} {'':8}{totals['totcomptime']:28.4f} {totals['totdecompstr']:>30}  {totals['totsize']:15,}")
 
 def benchmain():
     ''' Main benchmarking function '''
+    global do_compress, do_decompress
     tempfiles = dict()
 
     timefile = os.path.join(cfgConfig['temp_path'], 'zlib-time.tmp')
 
+    if cfgConfig['benchmark'] == 'compress':
+        do_compress = True
+        do_decompress = False
+    elif cfgConfig['benchmark'] == 'decompress':
+        do_compress = False
+        do_decompress = True
+    else:
+        do_compress = True
+        do_decompress = True
+
     # Detect external tools
-    benchmode = util.find_tools(timefile, use_prio=cfgTuning['use_prio'], use_perf=cfgConfig['use_perf'],
+    timemode = util.find_tools(timefile, use_prio=cfgTuning['use_prio'], use_perf=cfgConfig['use_perf'],
                                 use_turboctl=cfgTuning['use_turboctl'], use_cpupower=cfgTuning['use_cpupower'])
 
     printinfo()
@@ -192,8 +210,8 @@ def benchmain():
         shutil.copyfile(srcfile,tmp_filename)
         tmp_hash = util.hashfile(tmp_filename)
         origsize = os.path.getsize(tmp_filename)
-        print("\nActivated single file mode")
-        printfile(f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}", srcfile)
+        print("Activated single file mode")
+        benchmark.printfile(f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}", srcfile)
 
         for level in map(str, getlevels()):
             tempfiles[level] = dict()
@@ -215,10 +233,10 @@ def benchmain():
             if cfgRuns['testmode'] == 'multi':
                 srcfile = util.findfile(cfgMulti[level])
                 shutil.copyfile(srcfile,tmp_filename)
-                printfile(f"{level}", srcfile)
+                benchmark.printfile(f"{level}", srcfile)
             else:
                 util.generate_testfile(util.findfile(cfgGen['srcFile']),tmp_filename,cfgGen[level])
-                printfile(f"{level}", tmp_filename)
+                benchmark.printfile(f"{level}", tmp_filename)
 
             tempfiles[level]['hash'] = util.hashfile(tmp_filename)
             tempfiles[level]['origsize'] = os.path.getsize(tmp_filename)
@@ -231,6 +249,22 @@ def benchmain():
     for level in map(str, getlevels()):
         results[level] = []
 
+    # Prepare compressed files when only benchmarking decompress
+    if not do_compress and cfgRuns['testmode'] != 'multi':
+        cli.printnn("Compressing tempfiles for decompression test ")
+        if cfgRuns['testmode'] == 'single':
+            srcfile = cfgSingle['testfile']
+        else: # gen
+            srcfile = cfgGen['srcFile']
+        compfile = util.findfile(srcfile)
+
+        for level in map(str, getlevels()):
+            testtool = os.path.realpath(cfgRuns['testtool'])
+            tmp_compfile = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile)}-{level}.gz")
+            util.runcommand(f"{testtool} -{level} -c {tempfiles[level]['filename']}", output=tmp_compfile)
+            tempfiles[level]['filename'] = tmp_compfile
+            cli.printnn('.')
+
     # Run tests and record results
     for run in range(1,cfgRuns['runs']+1):
         if run != 1:
@@ -238,9 +272,9 @@ def benchmain():
 
         print(f"Starting run {run} of {cfgRuns['runs']}")
         for level in map(str, getlevels()):
-            compsize,comptime,decomptime,hashfail = benchmark.runtest(cfgRuns['testtool'], benchmode, cfgConfig['temp_path'],
+            compsize,comptime,decomptime,hashfail = benchmark.runtest(cfgRuns['testtool'], timemode, do_compress, do_decompress, cfgConfig['temp_path'],
                                                                       tempfiles, timefile, level, util.cmdprefix,
-                                                                      cfgConfig['skipdecomp'], cfgConfig['skipverify'])
+                                                                      cfgConfig['skipverify'])
             if hashfail != 0:
                 print(f"ERROR: level {level} failed crc checking")
             results[level].append( [compsize,comptime,decomptime] )
@@ -271,7 +305,7 @@ def main():
     parser.add_argument('-m','--multi', help='Activate testmode "Multi".', action='store_true')
     parser.add_argument('-g','--gen', help='Activate testmode "Generate".', action='store_true')
     parser.add_argument('-l','--testtool', help='Path to test tool.', action='store')
-    parser.add_argument('--skipdecomp', help='Skip decompression benchmarks.', action='store_true')
+    parser.add_argument('--benchmark', choices=['both','compress','decompress'], help='By default, benchmark both compress and decompress.', action='store')
     parser.add_argument('--skipverify', help='Skip verifying compressed files with system gzip.', action='store_true')
     args = parser.parse_args()
 
@@ -285,7 +319,6 @@ def main():
         else:
             print(f"ERROR: {defconfig_path} already exists, not overwriting.")
         sys.exit(1)
-
 
     # Load defconfig, then potentially override with values from config file
     cfg = config.defconfig()
@@ -352,8 +385,10 @@ def main():
         print(f"Error, unable to find '{cfgRuns['testtool']}' in current directory, did you forget to compile?")
         sys.exit(1)
 
-    if args.skipdecomp:
-        cfgConfig['skipdecomp'] = True
+    if args.benchmark == 'decompress':
+        cfgConfig['benchmark'] = 'decompress'
+    elif args.benchmark == 'compress':
+        cfgConfig['benchmark'] = 'compress'
 
     if args.skipverify:
         cfgConfig['skipverify'] = True

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -10,52 +10,61 @@ import os
 import sys
 import time
 
-from . import cli
 from . import util
+
+from .cli import printnn
 
 # Simple usleep function
 usleep = lambda x: time.sleep(x/1000000.0)
 
-def runtest(testtool, benchmode, temp_path, tempfiles, timefile, level, cmdprefix, skipdecomp, skipverify):
-    ''' Run benchmark and tests for current compression level'''
+def printfile(level, filename):
+    ''' Prints formatted information about file '''
+    filesize = os.path.getsize(filename)
+    print(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
+
+def run_timed(command, env, timefile, timemode, outfile):
+    ''' Run command and return the elapsed cputime (or realtime if unavailable) '''
+    starttime = time.perf_counter()
+    util.runcommand(command, env=env, output=outfile)
+
+    if timemode == 'python':
+        return time.perf_counter() - starttime
+
+    return util.parse_timefile(timefile)
+
+def runtest(testtool, timemode, do_compress, do_decompress, temp_path, tempfiles, timefile, level, cmdprefix, skipverify):
+    ''' Run benchmark and tests for current compression level '''
     # Prepare tempfiles
     compfile = os.path.join(temp_path, 'zlib-testfil.gz')
     decompfile = os.path.join(temp_path, 'zlib-testfil.raw')
 
-    hashfail, decomptime = 0,0
+    hashfail, comptime, decomptime = 0, 0, 0
     testfile = tempfiles[level]['filename']
     orighash = tempfiles[level]['hash']
 
     env = util.get_env(True)
+    testtool = os.path.realpath(testtool)
 
     sys.stdout.write(f"Testing level {level}: ")
     if sys.platform != 'win32':
-        util.runcommand('sync')
+        os.sync()
 
     # Compress
-    cli.printnn('c')
-    usleep(10)
-    starttime = time.perf_counter()
-    testtool = os.path.realpath(testtool)
-
-    util.runcommand(f"{cmdprefix} {testtool} -{level} -c {testfile}", env=env, output=compfile)
-    if benchmode == 'python':
-        comptime = time.perf_counter() - starttime
+    if do_compress:
+        printnn('c')
+        usleep(10)
+        comptime = run_timed(f"{cmdprefix} {testtool} -{level} -c {testfile}", env, timefile, timemode, compfile)
     else:
-        comptime = util.parse_timefile(timefile)
+        # compression disabled, just pass the file on to decompress
+        compfile = testfile
+
     compsize = os.path.getsize(compfile)
 
     # Decompress
-    if not skipdecomp or not skipverify:
-        cli.printnn('d')
+    if do_decompress or not skipverify:
+        printnn('d')
         usleep(10)
-        starttime = time.perf_counter()
-        util.runcommand(f"{cmdprefix} {testtool} -d -c {compfile}", env=env, output=decompfile)
-
-        if benchmode == 'python':
-            decomptime = time.perf_counter() - starttime
-        else:
-            decomptime = util.parse_timefile(timefile)
+        decomptime = run_timed(f"{cmdprefix} {testtool} -d -c {compfile}", env, timefile, timemode, decompfile)
 
         if not skipverify:
             ourhash = util.hashfile(decompfile)
@@ -66,8 +75,8 @@ def runtest(testtool, benchmode, temp_path, tempfiles, timefile, level, cmdprefi
         os.unlink(decompfile)
 
     # Validate using gunzip
-    if not skipverify:
-        cli.printnn('v')
+    if do_compress and not skipverify:
+        printnn('v')
         util.runcommand(f"gunzip -c {compfile}", output=decompfile)
 
         gziphash = util.hashfile(decompfile)
@@ -77,11 +86,17 @@ def runtest(testtool, benchmode, temp_path, tempfiles, timefile, level, cmdprefi
 
         os.unlink(decompfile)
 
+    # Cleanup
     if os.path.exists(timefile):
         os.unlink(timefile)
-    os.unlink(compfile)
+    if do_compress:
+        os.unlink(compfile)
 
     comppct = float(compsize*100)/tempfiles[level]['origsize']
-    cli.printnn(f" {comptime:7.4f} {decomptime:7.4f} {compsize:15,} {comppct:7.3f}%\n")
+    if do_compress:
+        printnn(f" {comptime:7.4f}s")
+    if do_decompress:
+        printnn(f" {decomptime:7.4f}s")
+    print(f" {compsize:15,}B {comppct:7.3f}%")
 
     return compsize,comptime,decomptime,hashfail

--- a/includes/config.py
+++ b/includes/config.py
@@ -22,7 +22,7 @@ def defconfig():
     config['Config'] = {'temp_path': tempfile.gettempdir(),
                         'use_perf': True,
                         'skipverify': False,
-                        'skipdecomp': False}
+                        'benchmark': 'both'} # both / compress / decompress
 
     ## CPU related settings
     config['Tuning'] = {'use_prio': True,


### PR DESCRIPTION
Reimplement benchmark modes: both, compress, decompress.
- Previously it was not possible to only benchmark decompression.
- This also removes config parameter 'skipdecomp' and adds 'benchmark'.

Refactor results compute and printing
- This makes both much easier to maintain, and printing is now a lot less fragile.