### PR TITLE
Add support for parsing level list and refactor parts of benchmark control code

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -224,13 +224,6 @@ def benchmain():
     # Tweak system to reduce benchmark variance
     util.cputweak(True)
 
-    # Prepare multilevel results array
-    calc_comp, calc_comptot, calc_decomp, calc_decomptot = None, None, None, None
-    result_comp, result_decomp = dict(), dict()
-    for level in map(str, levels):
-        result_comp[level] = []
-        result_decomp[level] = []
-
     # Prepare compressed files when only benchmarking decompress
     if not do_compress and cfgRuns['testmode'] != 'multi':
         printnn("Compressing tempfiles for decompression test ")
@@ -248,28 +241,32 @@ def benchmain():
             printnn('.')
         print('')
 
-    # Run tests and record results
-    for run in range(1,cfgRuns['runs']+1):
-        if run != 1:
-            cfgConfig['skipverify'] = True
+    # Prepare testconfig dict
+    testconfig = dict()
+    testconfig['runs'] = cfgRuns['runs']
+    testconfig['levels'] = levels
+    testconfig['skipverify'] = cfgConfig['skipverify']
+    testconfig['timemode'] = timemode
+    testconfig['timefile'] = timefile
+    testconfig['cmdprefix'] = util.cmdprefix
+    testconfig['testtool'] = os.path.realpath(cfgRuns['testtool'])
+    testconfig['do_compress'] = do_compress
+    testconfig['do_decompress'] = do_decompress
+    testconfig['tempfiles'] = tempfiles
+    testconfig['temp_path'] = cfgConfig['temp_path']
 
-        print(f"Starting run {run} of {cfgRuns['runs']}")
-        for level in map(str, levels):
-            compsize,comptime,decomptime,hashfail = benchmark.runtest(cfgRuns['testtool'], timemode, do_compress, do_decompress, cfgConfig['temp_path'],
-                                                                      tempfiles, timefile, level, util.cmdprefix,
-                                                                      cfgConfig['skipverify'])
-            if hashfail != 0:
-                print(f"ERROR: level {level} failed crc checking")
-            if do_compress:
-                result_comp[level].append( [compsize,comptime] )
-            if do_decompress:
-                result_decomp[level].append( [compsize,decomptime] )
+    # Run tests and record results
+    result_comp,result_decomp = benchmark.run_tests(testconfig)
+
+    # Calculate statistics
+    calc_comp, calc_comptot, calc_decomp, calc_decomptot = None, None, None, None
 
     if do_compress:
         calc_comp,calc_comptot = calculate(result_comp, tempfiles)
     if do_decompress:
         calc_decomp,calc_decomptot = calculate(result_decomp, tempfiles)
 
+    # Print info and results
     printinfo()
     printreport(calc_comp,calc_decomp,calc_comptot,calc_decomptot)
 

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -20,18 +20,14 @@ from includes import util
 
 from includes.cli import printnn
 
+levels = None
+
 def trimworst(results):
     ''' Trim X worst results '''
     results.sort()
     if not cfgRuns['trimworst']:
         return results
     return results[:-cfgRuns['trimworst']]
-
-def getlevels():
-    levels = list(range(cfgRuns['minlevel'],cfgRuns['maxlevel']+1))
-    for strategy in cfgRuns['strategies']:
-        levels.append(strategy)
-    return levels
 
 def calculate(results, tempfiles):
     ''' Calculate benchmark results '''
@@ -41,10 +37,10 @@ def calculate(results, tempfiles):
     res_comp, res_totals = dict(), dict()
 
     numresults = cfgRuns['runs'] - cfgRuns['trimworst']
-    numlevels = len(getlevels())
+    numlevels = len(levels)
 
     # Calculate and print stats per level
-    for level in map(str, getlevels()):
+    for level in levels:
         origsize = tempfiles[level]['origsize']
         comp = dict()
 
@@ -97,11 +93,12 @@ def calculate(results, tempfiles):
 
     # Averages/Totals
     res_totals['tottime'] = totcomptime
-    res_totals['avgpct'] = totcomppct/numlevels
-    res_totals['avgtime'] = totcomptime/(numlevels*numresults)
-    if cfgRuns['minlevel'] == 0:
-        res_totals['avgpct2'] = totcomppct2/(numlevels-1)
-        res_totals['avgtime2'] = totcomptime2/((numlevels-1)*numresults)
+    if numlevels > 1:
+        res_totals['avgpct'] = totcomppct/numlevels
+        res_totals['avgtime'] = totcomptime/(numlevels*numresults)
+        if 0 in levels:
+            res_totals['avgpct2'] = totcomppct2/(numlevels-1)
+            res_totals['avgtime2'] = totcomptime2/((numlevels-1)*numresults)
 
     return res_comp, res_totals
 
@@ -111,7 +108,7 @@ def printinfo():
     util.printsysinfo()
     print("")
     print(f"Tool: {cfgRuns['testtool']} Size: {os.path.getsize(cfgRuns['testtool']):,} B")
-    levelrange = f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}"
+    levelrange = ','.join(map(str, levels))
     print(f"Levels: {levelrange:10}")
     print(f"Runs: {str(cfgRuns['runs']):10} Trim worst: {str(cfgRuns['trimworst']):10}")
     print("")
@@ -144,7 +141,7 @@ def printreport(comp,decomp,comp_tot,decomp_tot):
     print_resultline('Level', 'Comp', 'Comptime min/avg/max/stddev', 'Decomptime min/avg/max/stddev', 'Compressed size')
 
     # Print level results
-    for level in map(str, getlevels()):
+    for level in levels:
         compstr, decompstr = '', ''
 
         if do_compress:
@@ -156,16 +153,18 @@ def printreport(comp,decomp,comp_tot,decomp_tot):
 
     # Print totals
     print('')
-    print_resultline('avg1', comp_tot['avgpct'], f"{comp_tot['avgtime']:.4f}", f"{decomp_tot['avgtime']:.4f}")
-    if cfgRuns['minlevel'] == 0:
-        print_resultline('avg2', comp_tot['avgpct2'], f"{comp_tot['avgtime2']:.4f}", f"{decomp_tot['avgtime2']:.4f}")
-    print('')
+    if len(levels) > 1:
+        print_resultline('avg1', comp_tot['avgpct'], f"{comp_tot['avgtime']:.4f}", f"{decomp_tot['avgtime']:.4f}")
+        if 0 in levels:
+            print_resultline('avg2', comp_tot['avgpct2'], f"{comp_tot['avgtime2']:.4f}", f"{decomp_tot['avgtime2']:.4f}")
+        print('')
 
 def benchmain():
     ''' Main benchmarking function '''
-    global do_compress, do_decompress
+    global do_compress, do_decompress, levels
     tempfiles = dict()
 
+    levels = benchmark.parse_levels(cfgRuns['levels'])
     timefile = os.path.join(cfgConfig['temp_path'], 'zlib-time.tmp')
 
     if cfgConfig['benchmark'] == 'compress':
@@ -192,9 +191,9 @@ def benchmain():
         tmp_hash = util.hashfile(tmp_filename)
         origsize = os.path.getsize(tmp_filename)
         print("Activated single file mode")
-        benchmark.printfile(f"{cfgRuns['minlevel']}-{cfgRuns['maxlevel']}", srcfile)
+        benchmark.printfile(','.join(map(str, levels)), srcfile)
 
-        for level in map(str, getlevels()):
+        for level in levels:
             tempfiles[level] = dict()
             tempfiles[level]['filename'] = tmp_filename
             tempfiles[level]['hash'] = tmp_hash
@@ -206,13 +205,13 @@ def benchmain():
         else:
             print(f"\nActivated multiple generated file mode. Source: {cfgGen['srcFile']}")
 
-        for level in map(str, getlevels()):
+        for level in map(str, levels):  # level is str for access Gen/Multi configs
             tempfiles[level] = dict()
             tmp_filename = os.path.join(cfgConfig['temp_path'], f"deflatebench-{level}.tmp")
             tempfiles[level]['filename'] = tmp_filename
 
             if cfgRuns['testmode'] == 'multi':
-                srcfile = util.findfile(cfgMulti[level])
+                srcfile = util.findfile(cfgMulti[level))
                 shutil.copyfile(srcfile,tmp_filename)
                 benchmark.printfile(f"{level}", srcfile)
             else:
@@ -228,7 +227,7 @@ def benchmain():
     # Prepare multilevel results array
     calc_comp, calc_comptot, calc_decomp, calc_decomptot = None, None, None, None
     result_comp, result_decomp = dict(), dict()
-    for level in map(str, getlevels()):
+    for level in map(str, levels):
         result_comp[level] = []
         result_decomp[level] = []
 
@@ -241,7 +240,7 @@ def benchmain():
             srcfile = cfgGen['srcFile']
         compfile = util.findfile(srcfile)
 
-        for level in map(str, getlevels()):
+        for level in levels:
             testtool = os.path.realpath(cfgRuns['testtool'])
             tmp_compfile = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile)}-{level}.gz")
             util.runcommand(f"{testtool} -{level} -c {tempfiles[level]['filename']}", output=tmp_compfile)
@@ -255,7 +254,7 @@ def benchmain():
             cfgConfig['skipverify'] = True
 
         print(f"Starting run {run} of {cfgRuns['runs']}")
-        for level in map(str, getlevels()):
+        for level in map(str, levels):
             compsize,comptime,decomptime,hashfail = benchmark.runtest(cfgRuns['testtool'], timemode, do_compress, do_decompress, cfgConfig['temp_path'],
                                                                       tempfiles, timefile, level, util.cmdprefix,
                                                                       cfgConfig['skipverify'])
@@ -278,7 +277,7 @@ def benchmain():
     util.cputweak(False)
 
     # Clean up tempfiles
-    for level in map(str, getlevels()):
+    for level in levels:
         if os.path.isfile(tempfiles[level]['filename']):
             os.unlink(tempfiles[level]['filename'])
 
@@ -287,14 +286,15 @@ def main():
     global cfgRuns,cfgConfig,cfgTuning,cfgGen,cfgSingle,cfgMulti
 
     parser = argparse.ArgumentParser(description='deflatebench - A zlib-ng benchmarking utility. Please see config file for more options.')
-    parser.add_argument('-r','--runs', help='Number of benchmark runs.', type=int)
-    parser.add_argument('-t','--trimworst', help='Trim the N worst runs per level.', type=int)
     parser.add_argument('-p','--profile', help='Load config profile from config file: ~/deflatebench-[PROFILE].conf')
     parser.add_argument('--write-config', help='Write default configfile to ~/deflatebench.conf.', action='store_true')
+    parser.add_argument('-l','--levels', help='Comma separated list of levels or level ranges.', action='store')
+    parser.add_argument('-r','--runs', help='Number of benchmark runs.', type=int)
+    parser.add_argument('--trimworst', help='Trim the N worst runs per level.', type=int)
     parser.add_argument('-s','--single', help='Activate testmode "Single"', action='store_true')
     parser.add_argument('-m','--multi', help='Activate testmode "Multi".', action='store_true')
     parser.add_argument('-g','--gen', help='Activate testmode "Generate".', action='store_true')
-    parser.add_argument('-l','--testtool', help='Path to test tool.', action='store')
+    parser.add_argument('--testtool', help='Path to test tool.', action='store')
     parser.add_argument('--benchmark', choices=['both','compress','decompress'], help='By default, benchmark both compress and decompress.', action='store')
     parser.add_argument('--skipverify', help='Skip verifying compressed files with system gzip.', action='store_true')
     args = parser.parse_args()
@@ -345,6 +345,9 @@ def main():
     if cfgRuns['runs'] <= cfgRuns['trimworst']:
         print(f"Error, parameter 'runs={cfgRuns['runs']}' needs to be higher than parameter 'trimworst={cfgRuns['trimworst']}'")
         sys.exit(1)
+
+    if args.levels:
+        cfgRuns['levels'] = args.levels
 
     if args.single:
         cfgRuns['testmode'] = 'single'

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -22,6 +22,31 @@ def printfile(level, filename):
     filesize = os.path.getsize(filename)
     print(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
 
+def parse_levels(level_string):
+    ''' Parse string containing comma-separated levels or level ranges '''
+    if not level_string or not level_string.strip():
+        raise ValueError("Levels string is empty")
+    levels = set()
+
+    try:
+        for part in level_string.split(','):
+            part = part.strip()
+            if not part:
+                continue
+
+            if '-' in part:
+                start, end = part.split('-', 1)
+                start, end = int(start), int(end)
+                if start > end:
+                    start, end = end, start
+                levels.update(range(start, end + 1))
+            else:
+                levels.add(int(part))
+    except ValueError as exc:
+        raise ValueError(f"Invalid level: '{part}'") from exc
+
+    return sorted(levels)
+
 def run_timed(command, env, timefile, timemode, outfile):
     ''' Run command and return the elapsed cputime (or realtime if unavailable) '''
     starttime = time.perf_counter()

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -9,6 +9,7 @@
 import os
 import sys
 import time
+from collections import namedtuple
 
 from . import util
 
@@ -57,28 +58,53 @@ def run_timed(command, env, timefile, timemode, outfile):
 
     return util.parse_timefile(timefile)
 
-def runtest(testtool, timemode, do_compress, do_decompress, temp_path, tempfiles, timefile, level, cmdprefix, skipverify):
+def run_tests(testconfig):
+    cfg = util.dict_to_namedt(testconfig)
+    skipverify = cfg.skipverify
+
+    # Prepare multilevel results arrays
+    result_comp, result_decomp = dict(), dict()
+    for level in cfg.levels:
+        result_comp[level] = []
+        result_decomp[level] = []
+
+    # Run tests and record results
+    for run in range(1, cfg.runs + 1):
+        if run != 1:
+            skipverify = True
+
+        print(f"Starting run {run} of {cfg.runs}")
+        for level in cfg.levels:
+            compsize,comptime,decomptime,hashfail = run_test(cfg, level, skipverify)
+            if hashfail != 0:
+                print(f"ERROR: level {level} failed crc checking")
+            if cfg.do_compress:
+                result_comp[level].append( [compsize,comptime] )
+            if cfg.do_decompress:
+                result_decomp[level].append( [compsize,decomptime] )
+
+    return result_comp, result_decomp
+
+def run_test(cfg, level, skipverify):
     ''' Run benchmark and tests for current compression level '''
     # Prepare tempfiles
-    compfile = os.path.join(temp_path, 'zlib-testfil.gz')
-    decompfile = os.path.join(temp_path, 'zlib-testfil.raw')
-
     hashfail, comptime, decomptime = 0, 0, 0
-    testfile = tempfiles[level]['filename']
-    orighash = tempfiles[level]['hash']
-
     env = util.get_env(True)
-    testtool = os.path.realpath(testtool)
+    orighash = cfg.tempfiles[level]['hash']
+
+    testfile = cfg.tempfiles[level]['filename']
+    compfile = os.path.join(cfg.temp_path, 'zlib-testfil.gz')
+    decompfile = os.path.join(cfg.temp_path, 'zlib-testfil.raw')
 
     sys.stdout.write(f"Testing level {level}: ")
     if sys.platform != 'win32':
         os.sync()
 
     # Compress
-    if do_compress:
+    if cfg.do_compress:
         printnn('c')
         usleep(10)
-        comptime = run_timed(f"{cmdprefix} {testtool} -{level} -c {testfile}", env, timefile, timemode, compfile)
+        comptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -{level} -c {testfile}", env, cfg.timefile, cfg.timemode, compfile)
     else:
         # compression disabled, just pass the file on to decompress
         compfile = testfile
@@ -86,10 +112,10 @@ def runtest(testtool, timemode, do_compress, do_decompress, temp_path, tempfiles
     compsize = os.path.getsize(compfile)
 
     # Decompress
-    if do_decompress or not skipverify:
+    if cfg.do_decompress or not skipverify:
         printnn('d')
         usleep(10)
-        decomptime = run_timed(f"{cmdprefix} {testtool} -d -c {compfile}", env, timefile, timemode, decompfile)
+        decomptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -d -c {compfile}", env, cfg.timefile, cfg.timemode, decompfile)
 
         if not skipverify:
             ourhash = util.hashfile(decompfile)
@@ -100,7 +126,7 @@ def runtest(testtool, timemode, do_compress, do_decompress, temp_path, tempfiles
         os.unlink(decompfile)
 
     # Validate using gunzip
-    if do_compress and not skipverify:
+    if cfg.do_compress and not skipverify:
         printnn('v')
         util.runcommand(f"gunzip -c {compfile}", output=decompfile)
 
@@ -112,15 +138,15 @@ def runtest(testtool, timemode, do_compress, do_decompress, temp_path, tempfiles
         os.unlink(decompfile)
 
     # Cleanup
-    if os.path.exists(timefile):
-        os.unlink(timefile)
-    if do_compress:
+    if os.path.exists(cfg.timefile):
+        os.unlink(cfg.timefile)
+    if cfg.do_compress:
         os.unlink(compfile)
 
-    comppct = float(compsize*100)/tempfiles[level]['origsize']
-    if do_compress:
+    comppct = float(compsize*100)/cfg.tempfiles[level]['origsize']
+    if cfg.do_compress:
         printnn(f" {comptime:7.4f}s")
-    if do_decompress:
+    if cfg.do_decompress:
         printnn(f" {decomptime:7.4f}s")
     print(f" {compsize:15,}B {comppct:7.3f}%")
 

--- a/includes/config.py
+++ b/includes/config.py
@@ -13,10 +13,9 @@ def defconfig():
     config = dict()
     config['Testruns'] = {  'runs': 15,
                             'trimworst': 5,
-                            'minlevel': 0,
-                            'maxlevel': 9,
-                            'strategies': '', # fhRF
-                            'testmode': 'single',  # generate / multi / single
+                            'levels': '1-8,9',       # comma-separated list of levels and/or ranges
+                            'strategy': '',          # TODO: Placeholder for now
+                            'testmode': 'single',    # generate / multi / single
                             'testtool': 'minigzip' } # minigzip / minideflate
 
     config['Config'] = {'temp_path': tempfile.gettempdir(),

--- a/includes/util.py
+++ b/includes/util.py
@@ -15,6 +15,8 @@ import subprocess
 import shlex
 import shutil
 
+from collections import namedtuple
+
 BUF_SIZE = 1024*1024  # lets read stuff in 1MB chunks when hashing or copying
 cmdprefix = ''
 
@@ -28,6 +30,9 @@ def get_env(bench=False):
     ''' Build dict of environment variables '''
     env = dict()
     return env
+
+def dict_to_namedt(dictionary):
+    return namedtuple('GenericDict', dictionary.keys())(**dictionary)
 
 def printsysinfo():
     ''' Print system information '''


### PR DESCRIPTION
Add support for comma separated list of levels and/or level ranges.
- Removes previous cmd parameters -t and -l.
- Add support for specifying levels from the command line using -l or --level.

Move tests runner to benchmarks module as run_tests().
- Pass test configuration to run_tests() using a dict.
- Have run_tests() and run_test() convert the dict to a read-only namedtuple for nicer code syntax.
