### PR TITLE
Support separate testfiles for compression and decompression

### DIFF
--- a/deflatebench.py
+++ b/deflatebench.py
@@ -211,45 +211,29 @@ def benchmain():
     if cfgRuns['testmode'] == 'single':
         tempfiles = benchmark.prepare_singlemode(testconfig, cfgSingle)
         testconfig['tempfiles'] = tempfiles
-    else:
+    elif cfgRuns['testmode'] == 'gen':
+        tempfiles = benchmark.prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp)
+        testconfig['tempfiles'] = tempfiles
+    elif cfgRuns['testmode'] == 'multi':
         # Multiple testfiles
-        if cfgRuns['testmode'] == 'multi':
-            print("\nActivated multiple file mode.")
-        else:
-            print(f"\nActivated multiple generated file mode. Source: {cfgGen['srcFile']}")
+        print("\nActivated multiple file mode.")
 
         for level in levels:
             tmp_filename = os.path.join(cfgConfig['temp_path'], f"deflatebench-{level}.tmp")
             tempfiles[level]['filename_comp'] = tmp_filename
             tempfiles[level]['filename_decomp'] = None
 
-            if cfgRuns['testmode'] == 'multi':
-                srcfile = util.findfile(cfgMulti[str(level)])
-                shutil.copyfile(srcfile,tmp_filename)
-                benchmark.printfile(f"{level}", srcfile)
-            else:
-                util.generate_testfile(util.findfile(cfgGen['srcFile']),tmp_filename,cfgGen[str(level)])
-                benchmark.printfile(f"{level}", tmp_filename)
+            srcfile = util.findfile(cfgMultiComp[str(level)])
+            shutil.copyfile(srcfile,tmp_filename)
+            benchmark.printfile(f"{level}", srcfile)
 
             tempfiles[level]['hash'] = util.hashfile(tmp_filename)
             tempfiles[level]['origsize_comp'] = os.path.getsize(tmp_filename)
 
+        testconfig['tempfiles'] = tempfiles
+
     # Tweak system to reduce benchmark variance
     util.cputweak(True)
-
-    # Prepare testconfig dict
-    testconfig = dict()
-    testconfig['runs'] = cfgRuns['runs']
-    testconfig['levels'] = levels
-    testconfig['skipverify'] = cfgConfig['skipverify']
-    testconfig['timemode'] = timemode
-    testconfig['timefile'] = timefile
-    testconfig['cmdprefix'] = util.cmdprefix
-    testconfig['testtool'] = os.path.realpath(cfgRuns['testtool'])
-    testconfig['do_compress'] = do_compress
-    testconfig['do_decompress'] = do_decompress
-    testconfig['tempfiles'] = tempfiles
-    testconfig['temp_path'] = cfgConfig['temp_path']
 
     # Run tests and record results
     result_comp,result_decomp = benchmark.run_tests(testconfig)
@@ -280,7 +264,7 @@ def benchmain():
 
 def main():
     ''' Main function handles command-line arguments and loading the correct config '''
-    global cfgRuns,cfgConfig,cfgTuning,cfgGen,cfgSingle,cfgMulti
+    global cfgRuns,cfgConfig,cfgTuning,cfgSingle,cfgGenComp,cfgGenDecomp,cfgMultiComp,cfgMultiDecomp
 
     parser = argparse.ArgumentParser(description='deflatebench - A zlib-ng benchmarking utility. Please see config file for more options.')
     parser.add_argument('-p','--profile', help='Load config profile from config file: ~/deflatebench-[PROFILE].conf')
@@ -292,8 +276,8 @@ def main():
     parser.add_argument('-m','--multi', help='Activate testmode "Multi".', action='store_true')
     parser.add_argument('-g','--gen', help='Activate testmode "Generate".', action='store_true')
     parser.add_argument('-f','--file', help='Path to test file to use for both comp/decomp (Single/Gen mode only).', action='store')
-    parser.add_argument('-x','--file-compress', help='Path to test file to use for compress (Single mode only).', action='store', dest='file_comp')
-    parser.add_argument('-y','--file-decompress', help='Path to test file to use for decompress (Single mode only).', action='store', dest='file_decomp')
+    parser.add_argument('-x','--file-compress', help='Path to test file to use for compress (Single/Gen mode only).', action='store', dest='file_comp')
+    parser.add_argument('-y','--file-decompress', help='Path to test file to use for decompress (Single/Gen mode only).', action='store', dest='file_decomp')
     parser.add_argument('--testtool', help='Path to test tool.', action='store')
     parser.add_argument('--benchmark', choices=['both','compress','decompress'], help='By default, benchmark both compress and decompress.', action='store')
     parser.add_argument('--skipverify', help='Skip verifying compressed files with system gzip.', action='store_true')
@@ -329,9 +313,11 @@ def main():
     cfgRuns = cfg['Testruns']
     cfgConfig = cfg['Config']
     cfgTuning = cfg['Tuning']
-    cfgGen = cfg['Testdata_Gen']
     cfgSingle = cfg['Testdata_Single']
-    cfgMulti = cfg['Testdata_Multi']
+    cfgGenComp = cfg['Testdata_Gen_Comp']
+    cfgGenDecomp = cfg['Testdata_Gen_Decomp']
+    cfgMultiComp = cfg['Testdata_Multi_Comp']
+    cfgMultiDecomp = cfg['Testdata_Multi_Decomp']
 
     util.init(cfgConfig, cfgTuning)
 
@@ -382,13 +368,16 @@ def main():
     if args.file:
         cfgSingle['testfile_compress'] = args.file
         cfgSingle['testfile_decompress'] = args.file
-        cfgGen['srcFile'] = args.file
+        cfgGenComp['srcFile'] = args.file
+        cfgGenDecomp['srcFile'] = args.file
 
     if args.file_comp:
         cfgSingle['testfile_compress'] = args.file_comp
+        cfgGenComp['srcFile'] = args.file_comp
 
     if args.file_decomp:
         cfgSingle['testfile_decompress'] = args.file_decomp
+        cfgGenDecomp['srcFile'] = args.file_decomp
 
     if args.testtool:
         cfgRuns['testtool'] = args.testtool

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -116,18 +116,24 @@ def printinfo():
     print(f"Runs: {str(cfgRuns['runs']):10} Trim worst: {str(cfgRuns['trimworst']):10}")
     print("")
 
-def print_resultline(header,pct,comp,decomp,size=None):
+def print_resultline(header,comp_pct,comp_size,comp,decomp_pct,decomp_size,decomp):
     printnn(f" {header:5}")
-    if isinstance(pct, float):
-        printnn(f"{pct:>7.3f}% ")
-    else:
-        printnn(f"{pct:>8} ")
     if do_compress:
-        printnn(f"{comp:>28} ")
+        if isinstance(comp_pct, float):
+            printnn(f"{comp_pct:>7.3f}% ")
+        else:
+            printnn(f"{comp_pct:>8} ")
+        printnn(f"{comp_size:>12} ")
+        printnn(f"{comp:>28}")
+    if do_compress and do_decompress:
+        printnn('  ')
     if do_decompress:
-        printnn(f"{decomp:>30} ")
-    if size is not None:
-        printnn(f" {size:15}")
+        if isinstance(decomp_pct, float):
+            printnn(f"{decomp_pct:>7.3f}% ")
+        else:
+            printnn(f"{decomp_pct:>8} ")
+        printnn(f"{decomp_size:>12} ")
+        printnn(f"{decomp:>30}")
     print('')
 
 def printreport(comp,decomp,comp_tot,decomp_tot):
@@ -141,7 +147,9 @@ def printreport(comp,decomp,comp_tot,decomp_tot):
         decomp_tot = comp_tot
 
     # Print header
-    print_resultline('Level', 'Comp', 'Comptime min/avg/max/stddev', 'Decomptime min/avg/max/stddev', 'Compressed size')
+    if do_compress and do_decompress:
+        print_resultline('', '|-     ', 'Compress', '-|', '|-     ', 'Decompress', '-|')
+    print_resultline('Level', 'Comp %', 'Out size', 'Comptime min/avg/max/stddev', 'Comp %', 'In size', 'Decomptime min/avg/max/stddev')
 
     # Print level results
     for level in levels:
@@ -152,14 +160,14 @@ def printreport(comp,decomp,comp_tot,decomp_tot):
         if do_decompress:
             decompstr = cli.resultstr(decomp[level],30)
 
-        print_resultline(level, comp[level]['avgpct'], compstr, decompstr, comp[level]['compsize'])
+        print_resultline(level, comp[level]['avgpct'], comp[level]['compsize'], compstr, decomp[level]['avgpct'], decomp[level]['compsize'], decompstr)
 
     # Print totals
     print('')
     if len(levels) > 1:
-        print_resultline('avg1', comp_tot['avgpct'], f"{comp_tot['avgtime']:.4f}", f"{decomp_tot['avgtime']:.4f}")
+        print_resultline('avg1', comp_tot['avgpct'], '', f"{comp_tot['avgtime']:.4f}", decomp_tot['avgpct'], '', f"{decomp_tot['avgtime']:.4f}")
         if 0 in levels:
-            print_resultline('avg2', comp_tot['avgpct2'], f"{comp_tot['avgtime2']:.4f}", f"{decomp_tot['avgtime2']:.4f}")
+            print_resultline('avg2', comp_tot['avgpct2'], '', f"{comp_tot['avgtime2']:.4f}", decomp_tot['avgpct2'], '', f"{decomp_tot['avgtime2']:.4f}")
         print('')
 
 def benchmain():
@@ -213,7 +221,6 @@ def benchmain():
                 decompress_hash = compress_hash
                 decompress_origsize = compress_origsize
             else: # Use separate files for compress and decompress benchmarks
-                #shutil.copyfile(srcfile,tmp_decompress_in)
                 separate_files = True
                 decompress_hash = util.hashfile(srcfile_decomp)
                 decompress_origsize = os.path.getsize(srcfile_decomp)

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -210,27 +210,11 @@ def benchmain():
     # Prepare tempfiles according to testmode selection
     if cfgRuns['testmode'] == 'single':
         tempfiles = benchmark.prepare_singlemode(testconfig, cfgSingle)
-        testconfig['tempfiles'] = tempfiles
     elif cfgRuns['testmode'] == 'gen':
         tempfiles = benchmark.prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp)
-        testconfig['tempfiles'] = tempfiles
     elif cfgRuns['testmode'] == 'multi':
-        # Multiple testfiles
-        print("\nActivated multiple file mode.")
-
-        for level in levels:
-            tmp_filename = os.path.join(cfgConfig['temp_path'], f"deflatebench-{level}.tmp")
-            tempfiles[level]['filename_comp'] = tmp_filename
-            tempfiles[level]['filename_decomp'] = None
-
-            srcfile = util.findfile(cfgMultiComp[str(level)])
-            shutil.copyfile(srcfile,tmp_filename)
-            benchmark.printfile(f"{level}", srcfile)
-
-            tempfiles[level]['hash'] = util.hashfile(tmp_filename)
-            tempfiles[level]['origsize_comp'] = os.path.getsize(tmp_filename)
-
-        testconfig['tempfiles'] = tempfiles
+        tempfiles = benchmark.prepare_multimode(testconfig, cfgMultiComp, cfgMultiDecomp)
+    testconfig['tempfiles'] = tempfiles
 
     # Tweak system to reduce benchmark variance
     util.cputweak(True)
@@ -357,11 +341,8 @@ def main():
     if args.file and (args.file_comp or args.file_decomp):
         print("Error, parameter '--file' conflicts with parameters '--file-compress' and '--file-decompress'")
         sys.exit(1)
-    elif (args.file_comp or args.file_decomp) and cfgRuns['testmode'] != 'single':
-        print("Error, parameters '--file-compress' and '--file-decompress' are only available with '--single'")
-        sys.exit(1)
-    elif args.file and cfgRuns['testmode'] == 'multi':
-        print("Error, parameter '--file' is not compatible with '--multi', please use config file.")
+    elif (args.file or args.file_comp or args.file_decomp) and cfgRuns['testmode'] == 'multi':
+        print("Error, parameters '--file', '--file-compress' and '--file-decompress' are not compatible with '--multi', please use config file.")
         sys.exit(1)
 
     # Handle testfile selection

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -29,7 +29,7 @@ def trimworst(results):
         return results
     return results[:-cfgRuns['trimworst']]
 
-def calculate(results, tempfiles):
+def calculate(results, tempfiles, is_compress):
     ''' Calculate benchmark results '''
     totsize, totsize2 = [0]*2
     totcomppct, totcomppct2 = [0]*2
@@ -41,7 +41,10 @@ def calculate(results, tempfiles):
 
     # Calculate and print stats per level
     for level in levels:
-        origsize = tempfiles[level]['origsize']
+        if is_compress:
+            origsize = tempfiles[level]['origsize_comp']
+        else:
+            origsize = tempfiles[level]['origsize_decomp']
         comp = dict()
 
         # Find best/worst times for this level
@@ -50,7 +53,7 @@ def calculate(results, tempfiles):
         for run in results[level]:
             rsize,rcompt = run
             rawcomptimes.append(rcompt)
-            if comp['compsize'] is not None and comp['compsize'] != rsize:
+            if is_compress and comp['compsize'] is not None and comp['compsize'] != rsize:
                 print(f"Warning: size changed between runs. Expected: {comp['compsize']} Got: {rsize}")
             else:
                 comp['compsize'] = rsize
@@ -163,6 +166,7 @@ def benchmain():
     ''' Main benchmarking function '''
     global do_compress, do_decompress, levels
     tempfiles = dict()
+    separate_files = False
 
     levels = benchmark.parse_levels(cfgRuns['levels'])
     timefile = os.path.join(cfgConfig['temp_path'], 'zlib-time.tmp')
@@ -183,21 +187,68 @@ def benchmain():
 
     printinfo()
 
-    # Single testfile, we just reference the same file for every level
+    for level in levels:
+        tempfiles[level] = dict()
+
+    # Single mode, we just reference the same file for every level
     if cfgRuns['testmode'] == 'single':
-        tmp_filename = os.path.join(cfgConfig['temp_path'], "deflatebench.tmp")
-        srcfile = util.findfile(cfgSingle['testfile'])
-        shutil.copyfile(srcfile,tmp_filename)
-        tmp_hash = util.hashfile(tmp_filename)
-        origsize = os.path.getsize(tmp_filename)
+        # filename_comp
+        if do_compress:
+            tmp_compress_in = os.path.join(cfgConfig['temp_path'], "deflatebench-comp.tmp")
+            srcfile_comp = util.findfile(cfgSingle['testfile_compress'])
+            shutil.copyfile(srcfile_comp,tmp_compress_in)
+            compress_hash = util.hashfile(tmp_compress_in)
+            compress_origsize = os.path.getsize(tmp_compress_in)
+        else:
+            tmp_compress_in = None
+            compress_hash = None
+            compress_origsize = None
+
+        # filename_decomp
+        if do_decompress:
+            tmp_decompress_in = os.path.join(cfgConfig['temp_path'], "deflatebench-decomp.tmp")
+            srcfile_decomp = util.findfile(cfgSingle['testfile_decompress'])
+            if do_compress and cfgSingle['testfile_compress'] == cfgSingle['testfile_decompress']:
+                tmp_decompress_in = None
+                decompress_hash = compress_hash
+                decompress_origsize = compress_origsize
+            else: # Use separate files for compress and decompress benchmarks
+                #shutil.copyfile(srcfile,tmp_decompress_in)
+                separate_files = True
+                decompress_hash = util.hashfile(srcfile_decomp)
+                decompress_origsize = os.path.getsize(srcfile_decomp)
+
+                # Prepare compressed files when only benchmarking decompress
+                printnn("Compressing tempfiles for decompression test ")
+                testtool = os.path.realpath(cfgRuns['testtool'])
+                for level in map(str, levels):
+                    tmp_decompress_in = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile_decomp)}-{level}.gz")
+                    util.runcommand(f"{testtool} -{level} -c {srcfile_decomp}", output=tmp_decompress_in)
+                    tempfiles[level]['filename_decomp'] = tmp_decompress_in
+                    printnn('.')
+        else:
+            tmp_decompress_in = None
+            decompress_hash = None
+            decompress_origsize = None
+
         print("Activated single file mode")
-        benchmark.printfile(','.join(map(str, levels)), srcfile)
+        if separate_files:
+            if do_compress:
+                benchmark.printfile(','.join(map(str, levels)), srcfile_comp, 'Compression')
+            if do_decompress:
+                benchmark.printfile(','.join(map(str, levels)), srcfile_decomp, 'Decompression')
+        else:
+            benchmark.printfile(','.join(map(str, levels)), srcfile_comp)
+
 
         for level in levels:
-            tempfiles[level] = dict()
-            tempfiles[level]['filename'] = tmp_filename
-            tempfiles[level]['hash'] = tmp_hash
-            tempfiles[level]['origsize'] = origsize
+            tempfiles[level]['filename_comp'] = tmp_compress_in
+            if not separate_files:
+                tempfiles[level]['filename_decomp'] = tmp_decompress_in
+            tempfiles[level]['hash_comp'] = compress_hash
+            tempfiles[level]['hash_decomp'] = decompress_hash
+            tempfiles[level]['origsize_comp'] = compress_origsize
+            tempfiles[level]['origsize_decomp'] = decompress_origsize
     else:
         # Multiple testfiles
         if cfgRuns['testmode'] == 'multi':
@@ -205,41 +256,24 @@ def benchmain():
         else:
             print(f"\nActivated multiple generated file mode. Source: {cfgGen['srcFile']}")
 
-        for level in map(str, levels):  # level is str for access Gen/Multi configs
-            tempfiles[level] = dict()
+        for level in levels:
             tmp_filename = os.path.join(cfgConfig['temp_path'], f"deflatebench-{level}.tmp")
-            tempfiles[level]['filename'] = tmp_filename
+            tempfiles[level]['filename_comp'] = tmp_filename
+            tempfiles[level]['filename_decomp'] = None
 
             if cfgRuns['testmode'] == 'multi':
-                srcfile = util.findfile(cfgMulti[level))
+                srcfile = util.findfile(cfgMulti[str(level)])
                 shutil.copyfile(srcfile,tmp_filename)
                 benchmark.printfile(f"{level}", srcfile)
             else:
-                util.generate_testfile(util.findfile(cfgGen['srcFile']),tmp_filename,cfgGen[level])
+                util.generate_testfile(util.findfile(cfgGen['srcFile']),tmp_filename,cfgGen[str(level)])
                 benchmark.printfile(f"{level}", tmp_filename)
 
             tempfiles[level]['hash'] = util.hashfile(tmp_filename)
-            tempfiles[level]['origsize'] = os.path.getsize(tmp_filename)
+            tempfiles[level]['origsize_comp'] = os.path.getsize(tmp_filename)
 
     # Tweak system to reduce benchmark variance
     util.cputweak(True)
-
-    # Prepare compressed files when only benchmarking decompress
-    if not do_compress and cfgRuns['testmode'] != 'multi':
-        printnn("Compressing tempfiles for decompression test ")
-        if cfgRuns['testmode'] == 'single':
-            srcfile = cfgSingle['testfile']
-        else: # gen
-            srcfile = cfgGen['srcFile']
-        compfile = util.findfile(srcfile)
-
-        for level in levels:
-            testtool = os.path.realpath(cfgRuns['testtool'])
-            tmp_compfile = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile)}-{level}.gz")
-            util.runcommand(f"{testtool} -{level} -c {tempfiles[level]['filename']}", output=tmp_compfile)
-            tempfiles[level]['filename'] = tmp_compfile
-            printnn('.')
-        print('')
 
     # Prepare testconfig dict
     testconfig = dict()
@@ -262,9 +296,9 @@ def benchmain():
     calc_comp, calc_comptot, calc_decomp, calc_decomptot = None, None, None, None
 
     if do_compress:
-        calc_comp,calc_comptot = calculate(result_comp, tempfiles)
+        calc_comp,calc_comptot = calculate(result_comp, tempfiles, True)
     if do_decompress:
-        calc_decomp,calc_decomptot = calculate(result_decomp, tempfiles)
+        calc_decomp,calc_decomptot = calculate(result_decomp, tempfiles, False)
 
     # Print info and results
     printinfo()
@@ -275,8 +309,12 @@ def benchmain():
 
     # Clean up tempfiles
     for level in levels:
-        if os.path.isfile(tempfiles[level]['filename']):
-            os.unlink(tempfiles[level]['filename'])
+        filename_comp = tempfiles[level]['filename_comp']
+        if do_compress and os.path.isfile(filename_comp):
+            os.unlink(filename_comp)
+        filename_decomp = tempfiles[level]['filename_decomp']
+        if do_decompress and filename_decomp and os.path.isfile(filename_decomp):
+            os.unlink(filename_decomp)
 
 def main():
     ''' Main function handles command-line arguments and loading the correct config '''
@@ -291,6 +329,9 @@ def main():
     parser.add_argument('-s','--single', help='Activate testmode "Single"', action='store_true')
     parser.add_argument('-m','--multi', help='Activate testmode "Multi".', action='store_true')
     parser.add_argument('-g','--gen', help='Activate testmode "Generate".', action='store_true')
+    parser.add_argument('-f','--file', help='Path to test file to use for both comp/decomp (Single/Gen mode only).', action='store')
+    parser.add_argument('-x','--file-compress', help='Path to test file to use for compress (Single mode only).', action='store', dest='file_comp')
+    parser.add_argument('-y','--file-decompress', help='Path to test file to use for decompress (Single mode only).', action='store', dest='file_decomp')
     parser.add_argument('--testtool', help='Path to test tool.', action='store')
     parser.add_argument('--benchmark', choices=['both','compress','decompress'], help='By default, benchmark both compress and decompress.', action='store')
     parser.add_argument('--skipverify', help='Skip verifying compressed files with system gzip.', action='store_true')
@@ -363,6 +404,29 @@ def main():
         if args.single or args.multi:
             print("Error, parameter '--gen' conflicts with parameters '--single' and '--multi'")
             sys.exit(1)
+
+    # Handle testfile error cases
+    if args.file and (args.file_comp or args.file_decomp):
+        print("Error, parameter '--file' conflicts with parameters '--file-compress' and '--file-decompress'")
+        sys.exit(1)
+    elif (args.file_comp or args.file_decomp) and cfgRuns['testmode'] != 'single':
+        print("Error, parameters '--file-compress' and '--file-decompress' are only available with '--single'")
+        sys.exit(1)
+    elif args.file and cfgRuns['testmode'] == 'multi':
+        print("Error, parameter '--file' is not compatible with '--multi', please use config file.")
+        sys.exit(1)
+
+    # Handle testfile selection
+    if args.file:
+        cfgSingle['testfile_compress'] = args.file
+        cfgSingle['testfile_decompress'] = args.file
+        cfgGen['srcFile'] = args.file
+
+    if args.file_comp:
+        cfgSingle['testfile_compress'] = args.file_comp
+
+    if args.file_decomp:
+        cfgSingle['testfile_decompress'] = args.file_decomp
 
     if args.testtool:
         cfgRuns['testtool'] = args.testtool

--- a/deflatebench.py
+++ b/deflatebench.py
@@ -174,7 +174,6 @@ def benchmain():
     ''' Main benchmarking function '''
     global do_compress, do_decompress, levels
     tempfiles = dict()
-    separate_files = False
 
     levels = benchmark.parse_levels(cfgRuns['levels'])
     timefile = os.path.join(cfgConfig['temp_path'], 'zlib-time.tmp')
@@ -195,67 +194,23 @@ def benchmain():
 
     printinfo()
 
-    for level in levels:
-        tempfiles[level] = dict()
+    # Prepare testconfig dict
+    testconfig = dict()
+    testconfig['runs'] = cfgRuns['runs']
+    testconfig['levels'] = levels
+    testconfig['skipverify'] = cfgConfig['skipverify']
+    testconfig['timemode'] = timemode
+    testconfig['timefile'] = timefile
+    testconfig['cmdprefix'] = util.cmdprefix
+    testconfig['testtool'] = os.path.realpath(cfgRuns['testtool'])
+    testconfig['do_compress'] = do_compress
+    testconfig['do_decompress'] = do_decompress
+    testconfig['temp_path'] = cfgConfig['temp_path']
 
-    # Single mode, we just reference the same file for every level
+    # Prepare tempfiles according to testmode selection
     if cfgRuns['testmode'] == 'single':
-        # filename_comp
-        if do_compress:
-            tmp_compress_in = os.path.join(cfgConfig['temp_path'], "deflatebench-comp.tmp")
-            srcfile_comp = util.findfile(cfgSingle['testfile_compress'])
-            shutil.copyfile(srcfile_comp,tmp_compress_in)
-            compress_hash = util.hashfile(tmp_compress_in)
-            compress_origsize = os.path.getsize(tmp_compress_in)
-        else:
-            tmp_compress_in = None
-            compress_hash = None
-            compress_origsize = None
-
-        # filename_decomp
-        if do_decompress:
-            tmp_decompress_in = os.path.join(cfgConfig['temp_path'], "deflatebench-decomp.tmp")
-            srcfile_decomp = util.findfile(cfgSingle['testfile_decompress'])
-            if do_compress and cfgSingle['testfile_compress'] == cfgSingle['testfile_decompress']:
-                tmp_decompress_in = None
-                decompress_hash = compress_hash
-                decompress_origsize = compress_origsize
-            else: # Use separate files for compress and decompress benchmarks
-                separate_files = True
-                decompress_hash = util.hashfile(srcfile_decomp)
-                decompress_origsize = os.path.getsize(srcfile_decomp)
-
-                # Prepare compressed files when only benchmarking decompress
-                printnn("Compressing tempfiles for decompression test ")
-                testtool = os.path.realpath(cfgRuns['testtool'])
-                for level in map(str, levels):
-                    tmp_decompress_in = os.path.join(cfgConfig['temp_path'], f"{os.path.basename(srcfile_decomp)}-{level}.gz")
-                    util.runcommand(f"{testtool} -{level} -c {srcfile_decomp}", output=tmp_decompress_in)
-                    tempfiles[level]['filename_decomp'] = tmp_decompress_in
-                    printnn('.')
-        else:
-            tmp_decompress_in = None
-            decompress_hash = None
-            decompress_origsize = None
-
-        print("Activated single file mode")
-        if separate_files:
-            if do_compress:
-                benchmark.printfile(','.join(map(str, levels)), srcfile_comp, 'Compression')
-            if do_decompress:
-                benchmark.printfile(','.join(map(str, levels)), srcfile_decomp, 'Decompression')
-        else:
-            benchmark.printfile(','.join(map(str, levels)), srcfile_comp)
-
-
-        for level in levels:
-            tempfiles[level]['filename_comp'] = tmp_compress_in
-            if not separate_files:
-                tempfiles[level]['filename_decomp'] = tmp_decompress_in
-            tempfiles[level]['hash_comp'] = compress_hash
-            tempfiles[level]['hash_decomp'] = decompress_hash
-            tempfiles[level]['origsize_comp'] = compress_origsize
-            tempfiles[level]['origsize_decomp'] = decompress_origsize
+        tempfiles = benchmark.prepare_singlemode(testconfig, cfgSingle)
+        testconfig['tempfiles'] = tempfiles
     else:
         # Multiple testfiles
         if cfgRuns['testmode'] == 'multi':

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -18,10 +18,13 @@ from .cli import printnn
 # Simple usleep function
 usleep = lambda x: time.sleep(x/1000000.0)
 
-def printfile(level, filename):
+def printfile(level, filename, comment=None):
     ''' Prints formatted information about file '''
     filesize = os.path.getsize(filename)
-    print(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
+    printnn(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
+    if comment:
+        printnn(f" {comment}")
+    print('')
 
 def parse_levels(level_string):
     ''' Parse string containing comma-separated levels or level ranges '''
@@ -88,13 +91,19 @@ def run_tests(testconfig):
 def run_test(cfg, level, skipverify):
     ''' Run benchmark and tests for current compression level '''
     # Prepare tempfiles
-    hashfail, comptime, decomptime = 0, 0, 0
+    hashfail, compsize, comptime, decomptime = 0, 0, 0, 0
     env = util.get_env(True)
-    orighash = cfg.tempfiles[level]['hash']
+    hash_comp = cfg.tempfiles[level]['hash_comp']
+    hash_decomp = cfg.tempfiles[level]['hash_decomp']
 
-    testfile = cfg.tempfiles[level]['filename']
-    compfile = os.path.join(cfg.temp_path, 'zlib-testfil.gz')
-    decompfile = os.path.join(cfg.temp_path, 'zlib-testfil.raw')
+    compress_in = cfg.tempfiles[level]['filename_comp']
+    compress_out = os.path.join(cfg.temp_path, 'zlib-testfil.gz')
+
+    if cfg.tempfiles[level]['filename_decomp'] is None:
+        decompress_in = compress_out
+    else:
+        decompress_in = cfg.tempfiles[level]['filename_decomp']
+    decompress_out = os.path.join(cfg.temp_path, 'zlib-testfil.raw')
 
     sys.stdout.write(f"Testing level {level}: ")
     if sys.platform != 'win32':
@@ -104,50 +113,47 @@ def run_test(cfg, level, skipverify):
     if cfg.do_compress:
         printnn('c')
         usleep(10)
-        comptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -{level} -c {testfile}", env, cfg.timefile, cfg.timemode, compfile)
-    else:
-        # compression disabled, just pass the file on to decompress
-        compfile = testfile
-
-    compsize = os.path.getsize(compfile)
+        comptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -{level} -c {compress_in}", env, cfg.timefile, cfg.timemode, compress_out)
+        compsize = os.path.getsize(compress_out)
 
     # Decompress
-    if cfg.do_decompress or not skipverify:
+    if cfg.do_decompress:
         printnn('d')
         usleep(10)
-        decomptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -d -c {compfile}", env, cfg.timefile, cfg.timemode, decompfile)
+        decompsize = os.path.getsize(decompress_in)
+        decomptime = run_timed(f"{cfg.cmdprefix} {cfg.testtool} -d -c {decompress_in}", env, cfg.timefile, cfg.timemode, decompress_out)
 
         if not skipverify:
-            ourhash = util.hashfile(decompfile)
-            if ourhash != orighash:
-                print(f"{orighash} != {ourhash}")
+            ourhash = util.hashfile(decompress_out)
+            if ourhash != hash_decomp:
+                print(f"\ndecompress: {hash_decomp} != {ourhash}")
                 hashfail = 1
 
-        os.unlink(decompfile)
+        os.unlink(decompress_out)
 
     # Validate using gunzip
     if cfg.do_compress and not skipverify:
         printnn('v')
-        util.runcommand(f"gunzip -c {compfile}", output=decompfile)
+        util.runcommand(f"gunzip -c {compress_out}", output=decompress_out)
 
-        gziphash = util.hashfile(decompfile)
-        if gziphash != orighash:
-            print(f"{orighash} != {gziphash}")
+        gziphash = util.hashfile(decompress_out)
+        if gziphash != hash_comp:
+            print(f"\nverify: {hash_comp} != {gziphash}")
             hashfail = 1
 
-        os.unlink(decompfile)
+        os.unlink(decompress_out)
 
     # Cleanup
     if os.path.exists(cfg.timefile):
         os.unlink(cfg.timefile)
     if cfg.do_compress:
-        os.unlink(compfile)
+        os.unlink(compress_out)
 
-    comppct = float(compsize*100)/cfg.tempfiles[level]['origsize']
     if cfg.do_compress:
-        printnn(f" {comptime:7.4f}s")
+        comppct = float(compsize*100)/cfg.tempfiles[level]['origsize_comp']
+        printnn(f"  comp: {comptime:.4f}s {compsize}B {comppct:.3f}%")
     if cfg.do_decompress:
-        printnn(f" {decomptime:7.4f}s")
-    print(f" {compsize:15,}B {comppct:7.3f}%")
+        printnn(f"  decomp: {decomptime:.4f}s {decompsize}B")
+    print('')
 
     return compsize,comptime,decomptime,hashfail

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -8,6 +8,7 @@
 
 import os
 import sys
+import shutil
 import time
 from collections import namedtuple
 
@@ -24,7 +25,7 @@ def printfile(level, filename, comment=None):
     printnn(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
     if comment:
         printnn(f" {comment}")
-    print('')
+    print('\n')
 
 def parse_levels(level_string):
     ''' Parse string containing comma-separated levels or level ranges '''
@@ -158,3 +159,81 @@ def run_test(cfg, level, skipverify):
     print('')
 
     return compsize,comptime,decompsize,decomptime,hashfail
+
+def get_empty_tempfiles(levels):
+    tempfiles = dict()
+    for level in levels:
+        tempfiles[level] = dict()
+        tempfiles[level]['filename_comp'] = None
+        tempfiles[level]['filename_decomp'] = None
+        tempfiles[level]['hash_comp'] = None
+        tempfiles[level]['hash_decomp'] = None
+        tempfiles[level]['origsize_comp'] = None
+        tempfiles[level]['origsize_decomp'] = None
+    return tempfiles
+
+def prepare_singlemode(testconfig, cfgSingle):
+    ''' Single mode, we use the same file for every level, but support separate files for compress/decompress '''
+    cfg = util.dict_to_namedt(testconfig)
+    tempfiles = get_empty_tempfiles(cfg.levels)
+
+    # Same input file for compress + decompress?
+    same_input_file = False
+    if cfg.do_compress and cfgSingle.get('testfile_compress') == cfgSingle.get('testfile_decompress'):
+        same_input_file = True
+
+    printnn("Preparing tempfiles ")
+
+    # Compress
+    if cfg.do_compress:
+        tmp_compress_in = os.path.join(cfg.temp_path, "deflatebench-comp.tmp")
+        srcfile_comp = util.findfile(cfgSingle['testfile_compress'])
+        shutil.copyfile(srcfile_comp,tmp_compress_in)
+        compress_hash = util.hashfile(tmp_compress_in)
+        compress_origsize = os.path.getsize(tmp_compress_in)
+        printnn('.')
+
+        # Set up tempfiles
+        for level in cfg.levels:
+            tempfiles[level]['filename_comp'] = tmp_compress_in
+            tempfiles[level]['hash_comp'] = compress_hash
+            tempfiles[level]['origsize_comp'] = compress_origsize
+
+    # Decompress
+    if cfg.do_decompress:
+        if same_input_file:
+            # Use the same file as compress
+            tmp_decompress_in = None
+            decompress_hash = compress_hash
+            decompress_origsize = compress_origsize
+        else: # Use separate files for compress and decompress benchmarks
+            srcfile_decomp = util.findfile(cfgSingle['testfile_decompress'])
+            decompress_hash = util.hashfile(srcfile_decomp)
+            decompress_origsize = os.path.getsize(srcfile_decomp)
+
+            # Prepare separate compressed files for each level of decompression benchmark
+            for level in cfg.levels:
+                tmp_decompress_in = os.path.join(cfg.temp_path, f"{os.path.basename(srcfile_decomp)}-{level}.gz")
+                util.runcommand(f"{cfg.testtool} -{level} -c {srcfile_decomp}", output=tmp_decompress_in)
+                tempfiles[level]['filename_decomp'] = tmp_decompress_in
+                printnn('.')
+
+        # Set up tempfiles
+        for level in cfg.levels:
+            if same_input_file:
+                tempfiles[level]['filename_decomp'] = tmp_decompress_in
+            tempfiles[level]['hash_decomp'] = decompress_hash
+            tempfiles[level]['origsize_decomp'] = decompress_origsize
+    print()
+
+    # Print a bit of info about the selected levels and files
+    print("Activated single file mode")
+    if not same_input_file:
+        if cfg.do_compress:
+            printfile(','.join(map(str, cfg.levels)), srcfile_comp, 'Compression')
+        if cfg.do_decompress:
+            printfile(','.join(map(str, cfg.levels)), srcfile_decomp, 'Decompression')
+    else:
+        printfile(','.join(map(str, cfg.levels)), srcfile_comp)
+
+    return tempfiles

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -237,3 +237,72 @@ def prepare_singlemode(testconfig, cfgSingle):
         printfile(','.join(map(str, cfg.levels)), srcfile_comp)
 
     return tempfiles
+
+def prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp):
+    ''' Gen mode, generate per-level tempfiles. Support separate input files for compress/decompress. '''
+    cfg = util.dict_to_namedt(testconfig)
+
+    tempfiles = dict()
+    for level in cfg.levels:
+        tempfiles[level] = dict()
+        tempfiles[level]['filename_comp'] = None
+        tempfiles[level]['filename_decomp'] = None
+        tempfiles[level]['hash_comp'] = None
+        tempfiles[level]['hash_decomp'] = None
+        tempfiles[level]['origsize_comp'] = None
+        tempfiles[level]['origsize_decomp'] = None
+
+    # Same input files for compress + decompress?
+    same_input_file = False
+    if cfg.do_compress and cfg.do_decompress:
+        if cfgGenDecomp['srcFile'] is None or cfgGenComp['srcFile'] == cfgGenDecomp['srcFile']:
+            same_input_file = True
+
+    printnn("Generating tempfiles ")
+
+    # Compress
+    if cfg.do_compress:
+        for level in cfg.levels:
+            tmp_comp = os.path.join(cfg.temp_path, f"deflatebench-comp-{level}.tmp")
+            util.generate_testfile(util.findfile(cfgGenComp['srcFile']), tmp_comp, cfgGenComp[str(level)])
+
+            tempfiles[level]['filename_comp'] = tmp_comp
+            tempfiles[level]['hash_comp'] = util.hashfile(tmp_comp)
+            tempfiles[level]['origsize_comp'] = os.path.getsize(tmp_comp)
+            printnn('.')
+
+    # Decompress
+    if cfg.do_decompress:
+        for level in cfg.levels:
+            if same_input_file:
+                # Reuse compression input for this level
+                tempfiles[level]['filename_decomp'] = None
+                tempfiles[level]['hash_decomp'] = tempfiles[level]['hash_comp']
+                tempfiles[level]['origsize_decomp'] = tempfiles[level]['origsize_comp']
+            else:
+                # Generate separate input file
+                tmp_raw = os.path.join(cfg.temp_path, f"deflatebench-decomp-{level}.tmp")
+                util.generate_testfile(util.findfile(cfgGenDecomp['srcFile']), tmp_raw, cfgGenDecomp[str(level)])
+
+                # Compress per-level file
+                tmp_decomp = os.path.join(cfg.temp_path, f"deflatebench-decomp-{level}.gz")
+                util.runcommand(f"{cfg.testtool} -{level} -c {tmp_raw}", output=tmp_decomp)
+
+                tempfiles[level]['filename_decomp'] = tmp_decomp
+                tempfiles[level]['hash_decomp'] = util.hashfile(tmp_raw)
+                tempfiles[level]['origsize_decomp'] = os.path.getsize(tmp_raw)
+                os.unlink(tmp_raw)
+            printnn('.')
+    print()
+
+    # Print a bit of info about the selected levels and files
+    print("Activated generated file mode")
+    if not same_input_file:
+        if cfg.do_compress:
+            printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenComp['srcFile']), 'Compression')
+        if cfg.do_decompress:
+            printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenDecomp['srcFile']), 'Decompression')
+    else:
+        printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenComp['srcFile']))
+
+    return tempfiles

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -78,20 +78,20 @@ def run_tests(testconfig):
 
         print(f"Starting run {run} of {cfg.runs}")
         for level in cfg.levels:
-            compsize,comptime,decomptime,hashfail = run_test(cfg, level, skipverify)
+            compsize,comptime,decompsize,decomptime,hashfail = run_test(cfg, level, skipverify)
             if hashfail != 0:
                 print(f"ERROR: level {level} failed crc checking")
             if cfg.do_compress:
                 result_comp[level].append( [compsize,comptime] )
             if cfg.do_decompress:
-                result_decomp[level].append( [compsize,decomptime] )
+                result_decomp[level].append( [decompsize,decomptime] )
 
     return result_comp, result_decomp
 
 def run_test(cfg, level, skipverify):
     ''' Run benchmark and tests for current compression level '''
     # Prepare tempfiles
-    hashfail, compsize, comptime, decomptime = 0, 0, 0, 0
+    hashfail, compsize, decompsize, comptime, decomptime = [0] * 5
     env = util.get_env(True)
     hash_comp = cfg.tempfiles[level]['hash_comp']
     hash_decomp = cfg.tempfiles[level]['hash_decomp']
@@ -151,9 +151,10 @@ def run_test(cfg, level, skipverify):
 
     if cfg.do_compress:
         comppct = float(compsize*100)/cfg.tempfiles[level]['origsize_comp']
-        printnn(f"  comp: {comptime:.4f}s {compsize}B {comppct:.3f}%")
+        printnn(f"   comp: {comptime:.4f}s {compsize}B {comppct:.3f}%")
     if cfg.do_decompress:
-        printnn(f"  decomp: {decomptime:.4f}s {decompsize}B")
+        decomppct = float(decompsize*100)/cfg.tempfiles[level]['origsize_decomp']
+        printnn(f"   decomp: {decomptime:.4f}s {decompsize}B {decomppct:.3f}%")
     print('')
 
-    return compsize,comptime,decomptime,hashfail
+    return compsize,comptime,decompsize,decomptime,hashfail

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -19,13 +19,43 @@ from .cli import printnn
 # Simple usleep function
 usleep = lambda x: time.sleep(x/1000000.0)
 
-def printfile(level, filename, comment=None):
+def print_file(level, filename, comment=''):
     ''' Prints formatted information about file '''
     filesize = os.path.getsize(filename)
-    printnn(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B")
-    if comment:
-        printnn(f" {comment}")
-    print('\n')
+    print(f"Level {level}: {filename} {filesize/1024/1024:6.1f} MiB  {filesize:12,} B  {comment}")
+
+def print_files(cfg, tempfiles, same_input=True, level_files=False):
+    ''' Prints formatted information about files '''
+    if not level_files and (same_input or not cfg.do_compress or not cfg.do_decompress):
+        if cfg.do_compress:
+            filename = tempfiles[cfg.levels[0]]['filename_comp']
+        elif cfg.do_decompress:
+            filename = tempfiles[cfg.levels[0]]['filename_decomp']
+        print_file(cfg.levels, filename)
+    elif not level_files:
+        if cfg.do_compress:
+            filename = tempfiles[cfg.levels[0]]['filename_comp']
+            print_file(cfg.levels, filename, 'Compression')
+        if cfg.do_decompress:
+            filename = tempfiles[cfg.levels[0]]['filename_decomp']
+            print_file(cfg.levels, filename, 'Decompression')
+    else:
+        if cfg.do_compress:
+            for level in cfg.levels:
+                filename = tempfiles[level]['filename_comp']
+                if same_input:
+                    print_file(level, filename)
+                else:
+                    print_file(level, filename, 'Compression')
+
+        if cfg.do_decompress:
+            for level in cfg.levels:
+                filename = tempfiles[level]['filename_decomp']
+                if same_input:
+                    print_file(level, filename)
+                else:
+                    print_file(level, filename, 'Decompression')
+    print()
 
 def parse_levels(level_string):
     ''' Parse string containing comma-separated levels or level ranges '''
@@ -227,14 +257,8 @@ def prepare_singlemode(testconfig, cfgSingle):
     print()
 
     # Print a bit of info about the selected levels and files
+    print_files(cfg, tempfiles, same_input=same_input_file)
     print("Activated single file mode")
-    if not same_input_file:
-        if cfg.do_compress:
-            printfile(','.join(map(str, cfg.levels)), srcfile_comp, 'Compression')
-        if cfg.do_decompress:
-            printfile(','.join(map(str, cfg.levels)), srcfile_decomp, 'Decompression')
-    else:
-        printfile(','.join(map(str, cfg.levels)), srcfile_comp)
 
     return tempfiles
 
@@ -287,14 +311,8 @@ def prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp):
     print()
 
     # Print a bit of info about the selected levels and files
+    print_files(cfg, tempfiles, same_input=same_input_file, level_files=True)
     print("Activated generated file mode")
-    if not same_input_file:
-        if cfg.do_compress:
-            printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenComp['srcFile']), 'Compression')
-        if cfg.do_decompress:
-            printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenDecomp['srcFile']), 'Decompression')
-    else:
-        printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenComp['srcFile']))
 
     return tempfiles
 
@@ -353,18 +371,7 @@ def prepare_multimode(testconfig, cfgMultiComp, cfgMultiDecomp):
     print()
 
     # Print a bit of info about the selected levels and files
-    print("Activated multiple file mode")
-    if not same_input_file:
-        if cfg.do_compress:
-            printfile(','.join(map(str, cfg.levels)),
-                      util.findfile(cfgMultiComp[str(cfg.levels[0])]),
-                      'Compression')
-        if cfg.do_decompress:
-            printfile(','.join(map(str, cfg.levels)),
-                      util.findfile(cfgMultiDecomp[str(cfg.levels[0])]),
-                      'Decompression')
-    else:
-        printfile(','.join(map(str, cfg.levels)),
-                  util.findfile(cfgMultiComp[str(cfg.levels[0])]))
+    print_files(cfg, tempfiles, same_input=same_input_file, level_files=True)
+    print("Activated multi file mode")
 
     return tempfiles

--- a/includes/benchmark.py
+++ b/includes/benchmark.py
@@ -241,16 +241,7 @@ def prepare_singlemode(testconfig, cfgSingle):
 def prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp):
     ''' Gen mode, generate per-level tempfiles. Support separate input files for compress/decompress. '''
     cfg = util.dict_to_namedt(testconfig)
-
-    tempfiles = dict()
-    for level in cfg.levels:
-        tempfiles[level] = dict()
-        tempfiles[level]['filename_comp'] = None
-        tempfiles[level]['filename_decomp'] = None
-        tempfiles[level]['hash_comp'] = None
-        tempfiles[level]['hash_decomp'] = None
-        tempfiles[level]['origsize_comp'] = None
-        tempfiles[level]['origsize_decomp'] = None
+    tempfiles = get_empty_tempfiles(cfg.levels)
 
     # Same input files for compress + decompress?
     same_input_file = False
@@ -304,5 +295,76 @@ def prepare_genmode(testconfig, cfgGenComp, cfgGenDecomp):
             printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenDecomp['srcFile']), 'Decompression')
     else:
         printfile(','.join(map(str, cfg.levels)), util.findfile(cfgGenComp['srcFile']))
+
+    return tempfiles
+
+def prepare_multimode(testconfig, cfgMultiComp, cfgMultiDecomp):
+    ''' Multi mode, use per-level input files. Support separate input files for compress/decompress. '''
+    cfg = util.dict_to_namedt(testconfig)
+    tempfiles = get_empty_tempfiles(cfg.levels)
+
+    # Same input files for compress + decompress?
+    if cfg.do_compress and cfg.do_decompress:
+        same_input_file = True
+        for level in cfg.levels:
+            if cfgMultiDecomp[str(level)] and cfgMultiComp[str(level)] and cfgMultiDecomp[str(level)] != cfgMultiComp[str(level)]:
+                same_input_file = False
+    else:
+        same_input_file = False
+
+    printnn("Preparing tempfiles ")
+
+    # Compress
+    if cfg.do_compress:
+        for level in cfg.levels:
+            srcfile = util.findfile(cfgMultiComp[str(level)])
+            tmp_comp = os.path.join(cfg.temp_path, f"deflatebench-comp-{level}.tmp")
+            shutil.copyfile(srcfile, tmp_comp)
+
+            tempfiles[level]['filename_comp'] = tmp_comp
+            tempfiles[level]['hash_comp'] = util.hashfile(tmp_comp)
+            tempfiles[level]['origsize_comp'] = os.path.getsize(tmp_comp)
+            printnn('.')
+
+    # Decompress
+    if cfg.do_decompress:
+        for level in cfg.levels:
+            if (same_input_file):
+                # Reuse compression input for this level
+                tempfiles[level]['filename_decomp'] = None
+                tempfiles[level]['hash_decomp'] = tempfiles[level]['hash_comp']
+                tempfiles[level]['origsize_decomp'] = tempfiles[level]['origsize_comp']
+            else:
+                # Separate input file
+                srcfile = util.findfile(cfgMultiDecomp[str(level)])
+
+                tmp_raw = os.path.join(cfg.temp_path, f"deflatebench-decomp-{level}.tmp")
+                shutil.copyfile(srcfile, tmp_raw)
+
+                tmp_decomp = os.path.join(cfg.temp_path, f"deflatebench-decomp-{level}.gz")
+                util.runcommand(f"{cfg.testtool} -{level} -c {tmp_raw}", output=tmp_decomp)
+
+                tempfiles[level]['filename_decomp'] = tmp_decomp
+                tempfiles[level]['hash_decomp'] = util.hashfile(tmp_raw)
+                tempfiles[level]['origsize_decomp'] = os.path.getsize(tmp_raw)
+                os.unlink(tmp_raw)
+
+            printnn('.')
+    print()
+
+    # Print a bit of info about the selected levels and files
+    print("Activated multiple file mode")
+    if not same_input_file:
+        if cfg.do_compress:
+            printfile(','.join(map(str, cfg.levels)),
+                      util.findfile(cfgMultiComp[str(cfg.levels[0])]),
+                      'Compression')
+        if cfg.do_decompress:
+            printfile(','.join(map(str, cfg.levels)),
+                      util.findfile(cfgMultiDecomp[str(cfg.levels[0])]),
+                      'Decompression')
+    else:
+        printfile(','.join(map(str, cfg.levels)),
+                  util.findfile(cfgMultiComp[str(cfg.levels[0])]))
 
     return tempfiles

--- a/includes/config.py
+++ b/includes/config.py
@@ -32,7 +32,8 @@ def defconfig():
                         'cpu_bench_speed': 2000 }
 
     # Single testfile
-    config['Testdata_Single'] = { 'testfile': 'silesia.tar' }
+    config['Testdata_Single'] = { 'testfile_compress': 'silesia.tar',
+                                  'testfile_decompress': 'silesia.tar' }
 
     # Multiple testfiles
     config['Testdata_Multi'] = {'0': 'testfile-500M',

--- a/includes/config.py
+++ b/includes/config.py
@@ -35,30 +35,55 @@ def defconfig():
     config['Testdata_Single'] = { 'testfile_compress': 'silesia.tar',
                                   'testfile_decompress': 'silesia.tar' }
 
-    # Multiple testfiles
-    config['Testdata_Multi'] = {'0': 'testfile-500M',
-                                '1': 'testfile-300M',
-                                '2': 'testfile-150M',
-                                '3': 'testfile-125M',
-                                '4': 'testfile-100M',
-                                '5': 'testfile-85M',
-                                '6': 'testfile-75M',
-                                '7': 'testfile-40M',
-                                '8': 'testfile-20M',
-                                '9': 'testfile-20M' }
+    # Multiple testfiles (compression)
+    config['Testdata_Multi_Comp'] = {'0': 'testfile-500M',
+                                     '1': 'testfile-300M',
+                                     '2': 'testfile-150M',
+                                     '3': 'testfile-125M',
+                                     '4': 'testfile-100M',
+                                     '5': 'testfile-85M',
+                                     '6': 'testfile-75M',
+                                     '7': 'testfile-40M',
+                                     '8': 'testfile-20M',
+                                     '9': 'testfile-20M' }
 
-    # Generated testfiles
-    config['Testdata_Gen'] =  { 'srcFile': 'silesia-small.tar',
-                                '0': 500,
-                                '1': 270,
-                                '2': 135,
-                                '3': 105,
-                                '4': 90,
-                                '5': 90,
-                                '6': 75,
-                                '7': 60,
-                                '8': 45,
-                                '9': 45 }
+    # Multiple testfiles (decompression)
+    config['Testdata_Multi_Decomp'] = {'0': 'testfile-500M',
+                                       '1': 'testfile-300M',
+                                       '2': 'testfile-150M',
+                                       '3': 'testfile-125M',
+                                       '4': 'testfile-100M',
+                                       '5': 'testfile-85M',
+                                       '6': 'testfile-75M',
+                                       '7': 'testfile-40M',
+                                       '8': 'testfile-20M',
+                                       '9': 'testfile-20M' }
+
+    # Generated testfiles (compression)
+    config['Testdata_Gen_Comp'] =  { 'srcFile': 'silesia-small.tar',
+                                     '0': 500,
+                                     '1': 270,
+                                     '2': 135,
+                                     '3': 105,
+                                     '4': 90,
+                                     '5': 90,
+                                     '6': 75,
+                                     '7': 60,
+                                     '8': 45,
+                                     '9': 45 }
+
+    # Generated testfiles (decompression)
+    config['Testdata_Gen_Decomp'] =  { 'srcFile': 'silesia-small.tar',
+                                       '0': 1000,
+                                       '1': 530,
+                                       '2': 270,
+                                       '3': 210,
+                                       '4': 180,
+                                       '5': 180,
+                                       '6': 150,
+                                       '7': 120,
+                                       '8': 90,
+                                       '9': 90 }
     return config
 
 def parseconfig(file):
@@ -80,10 +105,17 @@ def mergeconfig(src, chg):
         src['Config'].update(chg['Config'])
     if 'Tuning' in chg:
         src['Tuning'].update(chg['Tuning'])
-    if 'Testdata_Gen' in chg:
-        src['Testdata_Gen'].update(chg['Testdata_Gen'])
+
     if 'Testdata_Single' in chg:
         src['Testdata_Single'].update(chg['Testdata_Single'])
-    if 'Testdata_Multi' in chg:
-        src['Testdata_Multi'].update(chg['Testdata_Multi'])
+
+    if 'Testdata_Gen_Comp' in chg:
+        src['Testdata_Gen_Comp'].update(chg['Testdata_Gen_Comp'])
+    if 'Testdata_Gen_Decomp' in chg:
+        src['Testdata_Gen_Decomp'].update(chg['Testdata_Gen_Decomp'])
+
+    if 'Testdata_Multi_Comp' in chg:
+        src['Testdata_Multi_Comp'].update(chg['Testdata_Multi_Comp'])
+    if 'Testdata_Multi_Decomp' in chg:
+        src['Testdata_Multi_Decomp'].update(chg['Testdata_Multi_Decomp'])
     return src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 toml
+py-cpuinfo


### PR DESCRIPTION
Allows decoupling compression and decompression input files, letting you use bigger files for decompression tests for example.

Single mode works like it should.
Gen mode works like it should.
Multi mode works like it should.